### PR TITLE
Rebuild auto defender to latest requested layout

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,3 @@
+# Improvement Suggestions
+
+No additional improvement suggestions at this time.

--- a/script.lua
+++ b/script.lua
@@ -7,21 +7,39 @@ local tab = Menu.Create("General", "Auto Defender", "Auto Defender", "Auto Defen
 
 local info_group = tab:Create("Info")
 local activation_group = tab:Create("Activation", 1)
-local items_group = tab:Create("Items", 2)
-local priority_group = tab:Create("Priority", 3)
-local threshold_group = tab:Create("Health Thresholds", 4)
-local enemy_group = tab:Create("Enemy Checks", 5)
+local detection_group = tab:Create("Enemy Detection", 2)
 
 info_group:Label("Author: GhostyPowa")
+
+local SECTION_LAYOUT = {
+    { id = "defensive", title = "Defensive Items", order = 3 },
+    { id = "escape", title = "Escape Tools", order = 7 },
+    { id = "utility", title = "Utility Combos", order = 11 },
+    { id = "offensive", title = "Offensive Items", order = 15 },
+}
+
+local section_groups = {}
+for _, section in ipairs(SECTION_LAYOUT) do
+    local base = section.order
+    local toggles = tab:Create(section.title .. " - Toggles", base)
+    local priority = tab:Create(section.title .. " - Priority", base + 1)
+    local thresholds = tab:Create(section.title .. " - Thresholds", base + 2)
+    local enemy_checks = tab:Create(section.title .. " - Enemy Checks", base + 3)
+    priority:Label("Lower priority value means the item attempts earlier")
+    section_groups[section.id] = {
+        toggles = toggles,
+        priority = priority,
+        thresholds = thresholds,
+        enemy = enemy_checks,
+    }
+end
 
 local ui = {
     enable = activation_group:Switch("Enable", true),
     escape_turn_delay = activation_group:Slider("Force/Hurricane turn delay (ms)", 0, 500, 200, "%dms"),
-    enemy_range = enemy_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
+    enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
     items = {},
 }
-
-priority_group:Label("Lower priority value means the item attempts earlier")
 
 --#endregion
 
@@ -37,6 +55,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_glimmer_cape_fade",
+        category = "defensive",
     },
     {
         id = "ghost",
@@ -48,6 +67,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_ghost_state",
+        category = "defensive",
     },
     {
         id = "bkb",
@@ -59,6 +79,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_black_king_bar_immune",
+        category = "defensive",
     },
     {
         id = "pipe",
@@ -70,6 +91,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_pipe_barrier",
+        category = "defensive",
     },
     {
         id = "crimson",
@@ -81,6 +103,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_crimson_guard_nostack",
+        category = "defensive",
     },
     {
         id = "blade_mail",
@@ -92,6 +115,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_blade_mail_reflect",
+        category = "defensive",
     },
     {
         id = "lotus",
@@ -103,6 +127,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_lotus_orb_active",
+        category = "defensive",
     },
     {
         id = "solar_crest",
@@ -114,6 +139,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_solar_crest_armor",
+        category = "defensive",
     },
     {
         id = "drum",
@@ -125,6 +151,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
+        category = "defensive",
     },
     {
         id = "bearing",
@@ -136,6 +163,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
+        category = "defensive",
     },
     {
         id = "force",
@@ -148,6 +176,7 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         escape_distance = 600,
         active_modifier = "modifier_item_force_staff_active",
+        category = "escape",
     },
     {
         id = "hurricane",
@@ -160,6 +189,7 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         escape_distance = 600,
         active_modifier = "modifier_item_hurricane_pike",
+        category = "escape",
     },
     {
         id = "blink",
@@ -171,6 +201,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
+        category = "escape",
     },
     {
         id = "swift_blink",
@@ -182,6 +213,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
+        category = "escape",
     },
     {
         id = "arcane_blink",
@@ -193,6 +225,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
+        category = "escape",
     },
     {
         id = "overwhelming_blink",
@@ -204,6 +237,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
+        category = "escape",
     },
     {
         id = "meteor",
@@ -215,6 +249,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
+        category = "utility",
     },
     {
         id = "blood_grenade",
@@ -227,6 +262,7 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         requires_charges = true,
         cast_range_override = 900,
+        category = "offensive",
     },
     {
         id = "urn",
@@ -238,6 +274,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
+        category = "defensive",
     },
     {
         id = "vessel",
@@ -249,6 +286,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
+        category = "defensive",
     },
     {
         id = "disperser",
@@ -260,6 +298,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_disperser_speed",
+        category = "defensive",
     },
     {
         id = "eul",
@@ -271,6 +310,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_eul_cyclone",
+        category = "utility",
     },
     {
         id = "ethereal",
@@ -282,6 +322,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_ethereal_blade_ethereal",
+        category = "defensive",
     },
     {
         id = "halberd",
@@ -293,6 +334,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
+        category = "offensive",
     },
     {
         id = "atos",
@@ -304,6 +346,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 1100,
+        category = "offensive",
     },
     {
         id = "gleipnir",
@@ -315,6 +358,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 1100,
+        category = "offensive",
     },
     {
         id = "diffusal",
@@ -326,6 +370,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
+        category = "offensive",
     },
     {
         id = "nullifier",
@@ -337,6 +382,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
+        category = "offensive",
     },
     {
         id = "orchid",
@@ -348,6 +394,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
+        category = "offensive",
     },
     {
         id = "bloodthorn",
@@ -359,6 +406,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
+        category = "offensive",
     },
     {
         id = "hex",
@@ -370,6 +418,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 800,
+        category = "offensive",
     },
     {
         id = "abyssal",
@@ -381,6 +430,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
+        category = "offensive",
     },
     {
         id = "dagon",
@@ -398,17 +448,19 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 800,
+        category = "offensive",
     },
     {
         id = "wind_waker",
         display_name = "Wind Waker",
         icon = "panorama/images/items/wind_waker_png.vtex_c",
         ability_names = { "item_wind_waker" },
-        cast = "target_self",
+        cast = "eul_combo",
         threshold_default = 35,
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_wind_waker",
+        category = "utility",
     },
     {
         id = "silver_edge",
@@ -420,6 +472,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
+        category = "offensive",
     },
     {
         id = "shadow_blade",
@@ -431,6 +484,7 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_invisible",
+        category = "offensive",
     },
 }
 
@@ -438,16 +492,36 @@ local ITEM_BY_ID = {}
 local BLINK_ITEM_IDS = { "blink", "swift_blink", "arcane_blink", "overwhelming_blink" }
 --#endregion
 
+local function apply_icon(widget, icon)
+    if not widget or not icon then
+        return
+    end
+    if widget.SetImage then
+        widget:SetImage(icon)
+    elseif widget.SetIcon then
+        widget:SetIcon(icon)
+    elseif widget.Image then
+        widget:Image(icon)
+    elseif widget.Icon then
+        widget:Icon(icon)
+    end
+end
+
 for index, def in ipairs(ITEM_DEFINITIONS) do
     ITEM_BY_ID[def.id] = def
+    local section = section_groups[def.category or "defensive"] or section_groups.defensive
     local entry = {}
-    entry.enabled = items_group:Switch(def.display_name, true)
-    entry.priority = priority_group:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
+    entry.enabled = section.toggles:Switch(def.display_name, true)
+    apply_icon(entry.enabled, def.icon)
+    entry.priority = section.priority:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
+    apply_icon(entry.priority, def.icon)
     if not def.no_threshold then
-        entry.threshold = threshold_group:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
+        entry.threshold = section.thresholds:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
+        apply_icon(entry.threshold, def.icon)
     end
     if def.enemy_toggle then
-        entry.requires_enemy = enemy_group:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
+        entry.requires_enemy = section.enemy:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
+        apply_icon(entry.requires_enemy, def.icon)
     end
     ui.items[def.id] = entry
 end
@@ -635,6 +709,7 @@ local function build_priority_queue()
     return queue
 end
 --#endregion
+
 --#region Pending escape handling
 local pending_escapes = {}
 local pending_eul_blink = nil
@@ -829,6 +904,7 @@ local function process_pending_eul_blink(hero, detection_enemies)
     pending_eul_blink = nil
 end
 --#endregion
+
 --#region Casting logic
 local function cast_eul_combo(def, hero, ability, detection_enemies)
     Ability.CastTarget(ability, hero)
@@ -993,3 +1069,4 @@ function auto_defender.OnGameEnd()
 end
 
 return auto_defender
+

--- a/script.lua
+++ b/script.lua
@@ -84,7 +84,7 @@ local ITEM_DEFINITIONS = {
         icon = "panorama/images/items/wind_waker_png.vtex_c",
         display_name = "Wind Waker",
         type = "target_self",
-        modifier = "modifier_wind_waker_cyclone",
+        modifier = "modifier_item_wind_waker",
     },
     force = {
         item_name = "item_force_staff",
@@ -99,7 +99,7 @@ local ITEM_DEFINITIONS = {
         icon = "panorama/images/items/hurricane_pike_png.vtex_c",
         display_name = "Hurricane Pike",
         type = "escape_self",
-        modifier = "modifier_item_hurricane_pike_active",
+        modifier = "modifier_item_hurricane_pike",
         search_range = 1600,
     },
     atos = {

--- a/script.lua
+++ b/script.lua
@@ -1,1071 +1,804 @@
----@diagnostic disable: undefined-global, lowercase-global, param-type-mismatch
+---@diagnostic disable: undefined-global, lowercase-global, need-check-nil
 
 local auto_defender = {}
 
---#region UI setup
 local tab = Menu.Create("General", "Auto Defender", "Auto Defender", "Auto Defender")
-
-local info_group = tab:Create("Info")
-local activation_group = tab:Create("Activation", 1)
-local detection_group = tab:Create("Enemy Detection", 2)
-
-info_group:Label("Author: GhostyPowa")
-
-local SECTION_LAYOUT = {
-    { id = "defensive", title = "Defensive Items", order = 3 },
-    { id = "escape", title = "Escape Tools", order = 7 },
-    { id = "utility", title = "Utility Combos", order = 11 },
-    { id = "offensive", title = "Offensive Items", order = 15 },
-}
-
-local section_groups = {}
-for _, section in ipairs(SECTION_LAYOUT) do
-    local base = section.order
-    local toggles = tab:Create(section.title .. " - Toggles", base)
-    local priority = tab:Create(section.title .. " - Priority", base + 1)
-    local thresholds = tab:Create(section.title .. " - Thresholds", base + 2)
-    local enemy_checks = tab:Create(section.title .. " - Enemy Checks", base + 3)
-    priority:Label("Lower priority value means the item attempts earlier")
-    section_groups[section.id] = {
-        toggles = toggles,
-        priority = priority,
-        thresholds = thresholds,
-        enemy = enemy_checks,
-    }
+local info_group = tab:Create("Info", 0)
+if info_group.Label then
+    info_group:Label("Author: GhostyPowa")
+elseif info_group.Text then
+    info_group:Text("Author: GhostyPowa")
+else
+    local author_display = info_group:Switch("Author: GhostyPowa", false)
+    if author_display then
+        if author_display.SetEnabled then
+            author_display:SetEnabled(false)
+        elseif author_display.Disable then
+            author_display:Disable()
+        elseif author_display.SetState then
+            author_display:SetState(false)
+        end
+    end
 end
+
+local activation_group = tab:Create("Activation")
+local priority_group = tab:Create("Item Priority", 1)
+local threshold_group = tab:Create("Item Thresholds", 2)
 
 local ui = {
     enable = activation_group:Switch("Enable", true),
-    escape_turn_delay = activation_group:Slider("Force/Hurricane turn delay (ms)", 0, 500, 200, "%dms"),
-    enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
-    items = {},
 }
 
---#endregion
-
---#region Item definitions
 local ITEM_DEFINITIONS = {
-    {
-        id = "glimmer",
-        display_name = "Glimmer Cape",
+    glimmer = {
+        item_name = "item_glimmer_cape",
         icon = "panorama/images/items/glimmer_cape_png.vtex_c",
-        ability_names = { "item_glimmer_cape" },
-        cast = "target_self",
-        threshold_default = 50,
-        enemy_toggle = true,
-        enemy_required_default = true,
+        display_name = "Glimmer Cape",
+        type = "target_self",
         modifier = "modifier_item_glimmer_cape_fade",
-        category = "defensive",
     },
-    {
-        id = "ghost",
-        display_name = "Ghost Scepter",
+    ghost = {
+        item_name = "item_ghost",
         icon = "panorama/images/items/ghost_scepter_png.vtex_c",
-        ability_names = { "item_ghost" },
-        cast = "target_self",
-        threshold_default = 50,
-        enemy_toggle = true,
-        enemy_required_default = true,
+        display_name = "Ghost Scepter",
+        type = "no_target",
         modifier = "modifier_ghost_state",
-        category = "defensive",
     },
-    {
-        id = "bkb",
-        display_name = "Black King Bar",
+    bkb = {
+        item_name = "item_black_king_bar",
         icon = "panorama/images/items/black_king_bar_png.vtex_c",
-        ability_names = { "item_black_king_bar" },
-        cast = "no_target",
-        threshold_default = 50,
-        enemy_toggle = true,
-        enemy_required_default = true,
+        display_name = "Black King Bar",
+        type = "no_target",
         modifier = "modifier_black_king_bar_immune",
-        category = "defensive",
     },
-    {
-        id = "pipe",
-        display_name = "Pipe of Insight",
-        icon = "panorama/images/items/pipe_png.vtex_c",
-        ability_names = { "item_pipe" },
-        cast = "no_target",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_pipe_barrier",
-        category = "defensive",
-    },
-    {
-        id = "crimson",
-        display_name = "Crimson Guard",
-        icon = "panorama/images/items/crimson_guard_png.vtex_c",
-        ability_names = { "item_crimson_guard" },
-        cast = "no_target",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_crimson_guard_nostack",
-        category = "defensive",
-    },
-    {
-        id = "blade_mail",
-        display_name = "Blade Mail",
-        icon = "panorama/images/items/blade_mail_png.vtex_c",
-        ability_names = { "item_blade_mail" },
-        cast = "no_target",
-        threshold_default = 50,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_blade_mail_reflect",
-        category = "defensive",
-    },
-    {
-        id = "lotus",
-        display_name = "Lotus Orb",
+    lotus = {
+        item_name = "item_lotus_orb",
         icon = "panorama/images/items/lotus_orb_png.vtex_c",
-        ability_names = { "item_lotus_orb" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
+        display_name = "Lotus Orb",
+        type = "target_self",
         modifier = "modifier_item_lotus_orb_active",
-        category = "defensive",
     },
-    {
-        id = "solar_crest",
-        display_name = "Solar Crest",
-        icon = "panorama/images/items/solar_crest_png.vtex_c",
-        ability_names = { "item_solar_crest" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_solar_crest_armor",
-        category = "defensive",
+    crimson = {
+        item_name = "item_crimson_guard",
+        icon = "panorama/images/items/crimson_guard_png.vtex_c",
+        display_name = "Crimson Guard",
+        type = "no_target",
+        modifier = "modifier_item_crimson_guard_extra",
     },
-    {
-        id = "drum",
-        display_name = "Drum of Endurance",
-        icon = "panorama/images/items/ancient_janggo_png.vtex_c",
-        ability_names = { "item_ancient_janggo" },
-        cast = "no_target",
-        threshold_default = 55,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        requires_charges = true,
-        category = "defensive",
+    blade_mail = {
+        item_name = "item_blade_mail",
+        icon = "panorama/images/items/blade_mail_png.vtex_c",
+        display_name = "Blade Mail",
+        type = "no_target",
+        modifier = "modifier_item_blade_mail_reflect",
     },
-    {
-        id = "bearing",
-        display_name = "Boots of Bearing",
-        icon = "panorama/images/items/boots_of_bearing_png.vtex_c",
-        ability_names = { "item_boots_of_bearing" },
-        cast = "no_target",
-        threshold_default = 55,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        requires_charges = true,
-        category = "defensive",
-    },
-    {
-        id = "force",
-        display_name = "Force Staff",
-        icon = "panorama/images/items/force_staff_png.vtex_c",
-        ability_names = { "item_force_staff" },
-        cast = "force_escape",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        escape_distance = 600,
-        active_modifier = "modifier_item_force_staff_active",
-        category = "escape",
-    },
-    {
-        id = "hurricane",
-        display_name = "Hurricane Pike",
-        icon = "panorama/images/items/hurricane_pike_png.vtex_c",
-        ability_names = { "item_hurricane_pike" },
-        cast = "force_escape",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        escape_distance = 600,
-        active_modifier = "modifier_item_hurricane_pike",
-        category = "escape",
-    },
-    {
-        id = "blink",
-        display_name = "Blink Dagger",
-        icon = "panorama/images/items/blink_png.vtex_c",
-        ability_names = { "item_blink" },
-        cast = "blink_escape",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        blink_range = 1200,
-        category = "escape",
-    },
-    {
-        id = "swift_blink",
-        display_name = "Swift Blink",
-        icon = "panorama/images/items/swift_blink_png.vtex_c",
-        ability_names = { "item_swift_blink" },
-        cast = "blink_escape",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        blink_range = 1200,
-        category = "escape",
-    },
-    {
-        id = "arcane_blink",
-        display_name = "Arcane Blink",
-        icon = "panorama/images/items/arcane_blink_png.vtex_c",
-        ability_names = { "item_arcane_blink" },
-        cast = "blink_escape",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        blink_range = 1200,
-        category = "escape",
-    },
-    {
-        id = "overwhelming_blink",
-        display_name = "Overwhelming Blink",
-        icon = "panorama/images/items/overwhelming_blink_png.vtex_c",
-        ability_names = { "item_overwhelming_blink" },
-        cast = "blink_escape",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        blink_range = 1200,
-        category = "escape",
-    },
-    {
-        id = "meteor",
-        display_name = "Meteor Hammer",
-        icon = "panorama/images/items/meteor_hammer_png.vtex_c",
-        ability_names = { "item_meteor_hammer" },
-        cast = "meteor_combo",
-        no_threshold = true,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 600,
-        category = "utility",
-    },
-    {
-        id = "blood_grenade",
-        display_name = "Blood Grenade",
-        icon = "panorama/images/items/blood_grenade_png.vtex_c",
-        ability_names = { "item_blood_grenade" },
-        cast = "position_enemy",
-        threshold_default = 60,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        requires_charges = true,
-        cast_range_override = 900,
-        category = "offensive",
-    },
-    {
-        id = "urn",
-        display_name = "Urn of Shadows",
-        icon = "panorama/images/items/urn_of_shadows_png.vtex_c",
-        ability_names = { "item_urn_of_shadows" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        requires_charges = true,
-        category = "defensive",
-    },
-    {
-        id = "vessel",
-        display_name = "Spirit Vessel",
-        icon = "panorama/images/items/spirit_vessel_png.vtex_c",
-        ability_names = { "item_spirit_vessel" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        requires_charges = true,
-        category = "defensive",
-    },
-    {
-        id = "disperser",
-        display_name = "Disperser",
-        icon = "panorama/images/items/disperser_png.vtex_c",
-        ability_names = { "item_disperser" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_disperser_speed",
-        category = "defensive",
-    },
-    {
-        id = "eul",
-        display_name = "Eul's Scepter of Divinity",
+    eul = {
+        item_name = "item_cyclone",
         icon = "panorama/images/items/cyclone_png.vtex_c",
-        ability_names = { "item_cyclone" },
-        cast = "eul_combo",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
+        display_name = "Eul's Scepter",
+        type = "target_self",
         modifier = "modifier_eul_cyclone",
-        category = "utility",
     },
-    {
-        id = "ethereal",
-        display_name = "Ethereal Blade",
-        icon = "panorama/images/items/ethereal_blade_png.vtex_c",
-        ability_names = { "item_ethereal_blade" },
-        cast = "target_self",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_ethereal_blade_ethereal",
-        category = "defensive",
-    },
-    {
-        id = "halberd",
-        display_name = "Heaven's Halberd",
-        icon = "panorama/images/items/heavens_halberd_png.vtex_c",
-        ability_names = { "item_heavens_halberd" },
-        cast = "target_enemy",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 600,
-        category = "offensive",
-    },
-    {
-        id = "atos",
-        display_name = "Rod of Atos",
-        icon = "panorama/images/items/rod_of_atos_png.vtex_c",
-        ability_names = { "item_rod_of_atos" },
-        cast = "target_enemy",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 1100,
-        category = "offensive",
-    },
-    {
-        id = "gleipnir",
-        display_name = "Gleipnir",
-        icon = "panorama/images/items/gleipnir_png.vtex_c",
-        ability_names = { "item_gleipnir" },
-        cast = "position_enemy",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 1100,
-        category = "offensive",
-    },
-    {
-        id = "diffusal",
-        display_name = "Diffusal Blade",
-        icon = "panorama/images/items/diffusal_blade_png.vtex_c",
-        ability_names = { "item_diffusal_blade", "item_diffusal_blade_2" },
-        cast = "target_enemy",
-        threshold_default = 55,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 600,
-        category = "offensive",
-    },
-    {
-        id = "nullifier",
-        display_name = "Nullifier",
-        icon = "panorama/images/items/nullifier_png.vtex_c",
-        ability_names = { "item_nullifier" },
-        cast = "target_enemy",
-        threshold_default = 50,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 900,
-        category = "offensive",
-    },
-    {
-        id = "orchid",
-        display_name = "Orchid Malevolence",
-        icon = "panorama/images/items/orchid_png.vtex_c",
-        ability_names = { "item_orchid" },
-        cast = "target_enemy",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 900,
-        category = "offensive",
-    },
-    {
-        id = "bloodthorn",
-        display_name = "Bloodthorn",
-        icon = "panorama/images/items/bloodthorn_png.vtex_c",
-        ability_names = { "item_bloodthorn" },
-        cast = "target_enemy",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 900,
-        category = "offensive",
-    },
-    {
-        id = "hex",
-        display_name = "Scythe of Vyse",
-        icon = "panorama/images/items/sheepstick_png.vtex_c",
-        ability_names = { "item_sheepstick" },
-        cast = "target_enemy",
-        threshold_default = 40,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 800,
-        category = "offensive",
-    },
-    {
-        id = "abyssal",
-        display_name = "Abyssal Blade",
-        icon = "panorama/images/items/abyssal_blade_png.vtex_c",
-        ability_names = { "item_abyssal_blade" },
-        cast = "target_enemy",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 600,
-        category = "offensive",
-    },
-    {
-        id = "dagon",
-        display_name = "Dagon",
-        icon = "panorama/images/items/dagon_5_png.vtex_c",
-        ability_names = {
-            "item_dagon_5",
-            "item_dagon_4",
-            "item_dagon_3",
-            "item_dagon_2",
-            "item_dagon",
-        },
-        cast = "target_enemy",
-        threshold_default = 60,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 800,
-        category = "offensive",
-    },
-    {
-        id = "wind_waker",
-        display_name = "Wind Waker",
+    wind_waker = {
+        item_name = "item_wind_waker",
         icon = "panorama/images/items/wind_waker_png.vtex_c",
-        ability_names = { "item_wind_waker" },
-        cast = "eul_combo",
-        threshold_default = 35,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_item_wind_waker",
-        category = "utility",
+        display_name = "Wind Waker",
+        type = "target_self",
+        modifier = "modifier_wind_waker_cyclone",
     },
-    {
-        id = "silver_edge",
-        display_name = "Silver Edge",
+    force = {
+        item_name = "item_force_staff",
+        icon = "panorama/images/items/force_staff_png.vtex_c",
+        display_name = "Force Staff",
+        type = "escape_self",
+        modifier = "modifier_item_forcestaff_active",
+        search_range = 1600,
+    },
+    hurricane = {
+        item_name = "item_hurricane_pike",
+        icon = "panorama/images/items/hurricane_pike_png.vtex_c",
+        display_name = "Hurricane Pike",
+        type = "escape_self",
+        modifier = "modifier_item_hurricane_pike_active",
+        search_range = 1600,
+    },
+    atos = {
+        item_name = "item_rod_of_atos",
+        icon = "panorama/images/items/rod_of_atos_png.vtex_c",
+        display_name = "Rod of Atos",
+        type = "target_enemy",
+        enemy_modifier = "modifier_rod_of_atos_debuff",
+        range = 1100,
+    },
+    hex = {
+        item_name = "item_sheepstick",
+        icon = "panorama/images/items/sheepstick_png.vtex_c",
+        display_name = "Scythe of Vyse",
+        type = "target_enemy",
+        enemy_modifier = "modifier_sheepstick_debuff",
+        range = 800,
+    },
+    abyssal = {
+        item_name = "item_abyssal_blade",
+        icon = "panorama/images/items/abyssal_blade_png.vtex_c",
+        display_name = "Abyssal Blade",
+        type = "target_enemy",
+        enemy_modifier = "modifier_abyssal_blade_debuff",
+        range = 600,
+    },
+    diffusal = {
+        item_name = "item_diffusal_blade",
+        icon = "panorama/images/items/diffusal_blade_png.vtex_c",
+        display_name = "Diffusal Blade",
+        type = "target_enemy",
+        enemy_modifier = "modifier_item_diffusal_blade_slow",
+        range = 600,
+    },
+    gleipnir = {
+        item_name = "item_gleipnir",
+        icon = "panorama/images/items/gleipnir_png.vtex_c",
+        display_name = "Gleipnir",
+        type = "position_enemy",
+        enemy_modifier = "modifier_gleipnir_root",
+        range = 1100,
+    },
+    bloodthorn = {
+        item_name = "item_bloodthorn",
+        icon = "panorama/images/items/bloodthorn_png.vtex_c",
+        display_name = "Bloodthorn",
+        type = "target_enemy",
+        enemy_modifier = "modifier_bloodthorn_debuff",
+        range = 900,
+    },
+    silver = {
+        item_name = "item_silver_edge",
         icon = "panorama/images/items/silver_edge_png.vtex_c",
-        ability_names = { "item_silver_edge" },
-        cast = "no_target",
-        threshold_default = 45,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        cast_range_override = 600,
-        category = "offensive",
+        display_name = "Silver Edge",
+        type = "no_target",
+        modifier = "modifier_item_silver_edge_windwalk",
+        requires_enemy = true,
+        search_range = 1200,
     },
-    {
-        id = "shadow_blade",
+    shadow_blade = {
+        item_name = "item_invis_sword",
+        icon = "panorama/images/items/invis_sword_png.vtex_c",
         display_name = "Shadow Blade",
-        icon = "panorama/images/items/shadow_blade_png.vtex_c",
-        ability_names = { "item_invis_sword" },
-        cast = "no_target",
-        threshold_default = 55,
-        enemy_toggle = true,
-        enemy_required_default = true,
-        modifier = "modifier_invisible",
-        category = "offensive",
+        type = "no_target",
+        modifier = "modifier_item_invis_sword_windwalk",
+        requires_enemy = true,
+        search_range = 1200,
+    },
+    disperser = {
+        item_name = "item_disperser",
+        icon = "panorama/images/items/disperser_png.vtex_c",
+        display_name = "Disperser",
+        type = "target_self",
+        modifier = "modifier_item_disperser_active",
+    },
+    pipe = {
+        item_name = "item_pipe",
+        icon = "panorama/images/items/pipe_png.vtex_c",
+        display_name = "Pipe of Insight",
+        type = "no_target",
+        modifier = "modifier_item_pipe_barrier",
+    },
+    ethereal = {
+        item_name = "item_ethereal_blade",
+        icon = "panorama/images/items/ethereal_blade_png.vtex_c",
+        display_name = "Ethereal Blade",
+        type = "target_self",
+        modifier = "modifier_item_ethereal_blade_ethereal",
+    },
+    nullifier = {
+        item_name = "item_nullifier",
+        icon = "panorama/images/items/nullifier_png.vtex_c",
+        display_name = "Nullifier",
+        type = "target_enemy",
+        enemy_modifier = "modifier_item_nullifier_mute",
+        range = 900,
+    },
+    dagon = {
+        item_names = {
+            "item_dagon",
+            "item_dagon_2",
+            "item_dagon_3",
+            "item_dagon_4",
+            "item_dagon_5",
+        },
+        icon = "panorama/images/items/dagon_png.vtex_c",
+        display_name = "Dagon",
+        type = "target_enemy",
+        range = 900,
+    },
+    blood_grenade = {
+        item_name = "item_blood_grenade",
+        icon = "panorama/images/items/blood_grenade_png.vtex_c",
+        display_name = "Blood Grenade",
+        type = "position_enemy",
+        enemy_modifier = "modifier_item_blood_grenade_slow",
+        range = 900,
+        requires_charges = true,
+    },
+    halberd = {
+        item_name = "item_heavens_halberd",
+        icon = "panorama/images/items/heavens_halberd_png.vtex_c",
+        display_name = "Heaven's Halberd",
+        type = "target_enemy",
+        enemy_modifier = "modifier_heavens_halberd_debuff",
+        range = 600,
+    },
+    urn = {
+        item_name = "item_urn_of_shadows",
+        icon = "panorama/images/items/urn_of_shadows_png.vtex_c",
+        display_name = "Urn of Shadows",
+        type = "target_self",
+        modifier = "modifier_item_urn_heal",
+        requires_charges = true,
+    },
+    spirit_vessel = {
+        item_name = "item_spirit_vessel",
+        icon = "panorama/images/items/spirit_vessel_png.vtex_c",
+        display_name = "Spirit Vessel",
+        type = "target_self",
+        modifier = "modifier_item_spirit_vessel_heal",
+        requires_charges = true,
+    },
+    blink = {
+        item_name = "item_blink",
+        icon = "panorama/images/items/blink_png.vtex_c",
+        display_name = "Blink Dagger",
+        type = "escape_position",
+        range = 1200,
+        escape_distance = 1150,
+    },
+    overwhelming_blink = {
+        item_name = "item_overwhelming_blink",
+        icon = "panorama/images/items/overwhelming_blink_png.vtex_c",
+        display_name = "Overwhelming Blink",
+        type = "escape_position",
+        range = 1200,
+        escape_distance = 1150,
+    },
+    swift_blink = {
+        item_name = "item_swift_blink",
+        icon = "panorama/images/items/swift_blink_png.vtex_c",
+        display_name = "Swift Blink",
+        type = "escape_position",
+        range = 1200,
+        escape_distance = 1150,
+    },
+    arcane_blink = {
+        item_name = "item_arcane_blink",
+        icon = "panorama/images/items/arcane_blink_png.vtex_c",
+        display_name = "Arcane Blink",
+        type = "escape_position",
+        range = 1200,
+        escape_distance = 1150,
+    },
+    solar_crest = {
+        item_name = "item_solar_crest",
+        icon = "panorama/images/items/solar_crest_png.vtex_c",
+        display_name = "Solar Crest",
+        type = "target_self",
+        modifier = "modifier_item_solar_crest_armor_addition",
+    },
+    drums = {
+        item_name = "item_ancient_janggo",
+        icon = "panorama/images/items/ancient_janggo_png.vtex_c",
+        display_name = "Drum of Endurance",
+        type = "no_target",
+        modifier = "modifier_item_ancient_janggo_active",
+    },
+    boots_of_bearing = {
+        item_name = "item_boots_of_bearing",
+        icon = "panorama/images/items/boots_of_bearing_png.vtex_c",
+        display_name = "Boots of Bearing",
+        type = "no_target",
+        modifier = "modifier_item_boots_of_bearing_active",
     },
 }
 
-local ITEM_BY_ID = {}
-local BLINK_ITEM_IDS = { "blink", "swift_blink", "arcane_blink", "overwhelming_blink" }
---#endregion
+local priority_items = {
+    { "glimmer", ITEM_DEFINITIONS.glimmer.icon, true },
+    { "ghost", ITEM_DEFINITIONS.ghost.icon, true },
+    { "bkb", ITEM_DEFINITIONS.bkb.icon, true },
+    { "lotus", ITEM_DEFINITIONS.lotus.icon, false },
+    { "crimson", ITEM_DEFINITIONS.crimson.icon, false },
+    { "blade_mail", ITEM_DEFINITIONS.blade_mail.icon, false },
+    { "eul", ITEM_DEFINITIONS.eul.icon, false },
+    { "wind_waker", ITEM_DEFINITIONS.wind_waker.icon, false },
+    { "force", ITEM_DEFINITIONS.force.icon, false },
+    { "hurricane", ITEM_DEFINITIONS.hurricane.icon, false },
+    { "disperser", ITEM_DEFINITIONS.disperser.icon, false },
+    { "pipe", ITEM_DEFINITIONS.pipe.icon, false },
+    { "ethereal", ITEM_DEFINITIONS.ethereal.icon, false },
+    { "nullifier", ITEM_DEFINITIONS.nullifier.icon, false },
+    { "dagon", ITEM_DEFINITIONS.dagon.icon, false },
+    { "blood_grenade", ITEM_DEFINITIONS.blood_grenade.icon, false },
+    { "halberd", ITEM_DEFINITIONS.halberd.icon, false },
+    { "urn", ITEM_DEFINITIONS.urn.icon, false },
+    { "spirit_vessel", ITEM_DEFINITIONS.spirit_vessel.icon, false },
+    { "blink", ITEM_DEFINITIONS.blink.icon, false },
+    { "overwhelming_blink", ITEM_DEFINITIONS.overwhelming_blink.icon, false },
+    { "swift_blink", ITEM_DEFINITIONS.swift_blink.icon, false },
+    { "arcane_blink", ITEM_DEFINITIONS.arcane_blink.icon, false },
+    { "solar_crest", ITEM_DEFINITIONS.solar_crest.icon, false },
+    { "drums", ITEM_DEFINITIONS.drums.icon, false },
+    { "boots_of_bearing", ITEM_DEFINITIONS.boots_of_bearing.icon, false },
+    { "atos", ITEM_DEFINITIONS.atos.icon, false },
+    { "hex", ITEM_DEFINITIONS.hex.icon, false },
+    { "abyssal", ITEM_DEFINITIONS.abyssal.icon, false },
+    { "bloodthorn", ITEM_DEFINITIONS.bloodthorn.icon, false },
+    { "diffusal", ITEM_DEFINITIONS.diffusal.icon, false },
+    { "gleipnir", ITEM_DEFINITIONS.gleipnir.icon, false },
+    { "silver", ITEM_DEFINITIONS.silver.icon, false },
+    { "shadow_blade", ITEM_DEFINITIONS.shadow_blade.icon, false },
+}
 
-local function apply_icon(widget, icon)
-    if not widget or not icon then
-        return
-    end
-    if widget.SetImage then
-        widget:SetImage(icon)
-    elseif widget.SetIcon then
-        widget:SetIcon(icon)
-    elseif widget.Image then
-        widget:Image(icon)
-    elseif widget.Icon then
-        widget:Icon(icon)
+local priority_widget = priority_group:MultiSelect("Items", priority_items, true)
+priority_widget:DragAllowed(true)
+priority_widget:ToolTip("Drag to reorder priority. Enable items you want to use.")
+
+local item_thresholds = {}
+
+for _, item in ipairs(priority_items) do
+    local key = item[1]
+    local definition = ITEM_DEFINITIONS[key]
+    if definition then
+        item_thresholds[key] = threshold_group:Slider(
+            definition.display_name,
+            1,
+            100,
+            50,
+            function(value)
+                return string.format("%d%%", value)
+            end
+        )
     end
 end
 
-for index, def in ipairs(ITEM_DEFINITIONS) do
-    ITEM_BY_ID[def.id] = def
-    local section = section_groups[def.category or "defensive"] or section_groups.defensive
-    local entry = {}
-    entry.enabled = section.toggles:Switch(def.display_name, true)
-    apply_icon(entry.enabled, def.icon)
-    entry.priority = section.priority:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
-    apply_icon(entry.priority, def.icon)
-    if not def.no_threshold then
-        entry.threshold = section.thresholds:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
-        apply_icon(entry.threshold, def.icon)
-    end
-    if def.enemy_toggle then
-        entry.requires_enemy = section.enemy:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
-        apply_icon(entry.requires_enemy, def.icon)
-    end
-    ui.items[def.id] = entry
-end
+local CAST_COOLDOWN = 0.2
+local last_cast_times = {}
 
---#region Helpers
-local function get_local_hero()
-    local hero = Heroes.GetLocal()
-    if not hero then
-        return nil
-    end
+local CONTROL_BLOCKERS = {
+    Enum.ModifierState.MODIFIER_STATE_STUNNED,
+    Enum.ModifierState.MODIFIER_STATE_HEXED,
+    Enum.ModifierState.MODIFIER_STATE_MUTED,
+}
+
+local DEFAULT_SEARCH_RANGE = 1200
+
+local function can_use_item(hero)
     if not Entity.IsAlive(hero) then
-        return nil
+        return false
     end
-    if Entity.IsDormant(hero) then
-        return nil
-    end
-    if NPC.IsIllusion(hero) then
-        return nil
-    end
-    return hero
-end
 
-local function health_percent(hero)
-    local health = Entity.GetHealth(hero)
-    local max_health = Entity.GetMaxHealth(hero)
-    if max_health <= 0 then
-        return 100
-    end
-    return (health / max_health) * 100
-end
-
-local function find_item(hero, names)
-    for _, name in ipairs(names) do
-        local ability = NPC.GetItem(hero, name, true)
-        if ability then
-            return ability
+    for _, state in ipairs(CONTROL_BLOCKERS) do
+        if NPC.HasState(hero, state) then
+            return false
         end
     end
+
+    return true
+end
+
+local function is_recently_cast(item_id, game_time)
+    local last_time = last_cast_times[item_id]
+    if not last_time then
+        return false
+    end
+    return game_time - last_time < CAST_COOLDOWN
+end
+
+local function mark_cast(item_id, game_time)
+    last_cast_times[item_id] = game_time
+end
+
+local function get_enabled_items()
+    local ordered = priority_widget:List()
+    local enabled = {}
+
+    for _, key in ipairs(ordered) do
+        if priority_widget:Get(key) then
+            enabled[#enabled + 1] = key
+        end
+    end
+
+    return enabled
+end
+
+local function get_inventory_item(hero, definition)
+    if definition.item_name then
+        return NPC.GetItem(hero, definition.item_name, true)
+    end
+
+    if definition.item_names then
+        for _, name in ipairs(definition.item_names) do
+            local item = NPC.GetItem(hero, name, true)
+            if item then
+                return item
+            end
+        end
+    end
+
     return nil
 end
 
-local function ability_is_valid(hero, ability)
-    if not ability then
-        return false
+local function get_effective_cast_range(hero, ability, definition)
+    local range = Ability.GetCastRange(ability)
+    if not range or range < 0 then
+        range = 0
     end
-    if Ability.IsPassive(ability) then
-        return false
+
+    local bonus = NPC.GetCastRangeBonus(hero)
+    if bonus and bonus > 0 then
+        range = range + bonus
     end
-    if Ability.IsHidden(ability) then
-        return false
+
+    if definition and definition.range then
+        range = math.max(range, definition.range)
     end
-    if Ability.GetOwner(ability) ~= hero then
-        return false
+
+    if range <= 0 then
+        range = definition and definition.search_range or DEFAULT_SEARCH_RANGE
     end
-    if not Ability.IsActivated(ability) then
-        return false
-    end
-    if not Ability.IsReady(ability) then
-        return false
-    end
-    if not Ability.IsCastable(ability, NPC.GetMana(hero)) then
-        return false
-    end
-    return true
+
+    return range
 end
 
-local function item_has_charges(ability)
-    if not ability then
-        return false
+local function find_enemy_target(hero, ability, definition)
+    local range = get_effective_cast_range(hero, ability, definition)
+    if range <= 0 then
+        return nil
     end
-    local charges = Ability.GetCurrentCharges(ability)
-    if charges == nil then
-        return true
-    end
-    return charges > 0
-end
 
-local function collect_enemies(hero, radius)
-    local enemies = Entity.GetHeroesInRadius(hero, radius, Enum.TeamType.TEAM_ENEMY, true, true)
-    local result = {}
-    if not enemies then
-        return result
+    local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
+    if not enemies or #enemies == 0 then
+        return nil
     end
-    for _, enemy in ipairs(enemies) do
-        if enemy ~= hero and Entity.IsAlive(enemy) and not Entity.IsDormant(enemy) and not NPC.IsIllusion(enemy) then
-            table.insert(result, enemy)
-        end
-    end
-    return result
-end
 
-local function find_closest_enemy(hero, search_radius)
     local hero_pos = Entity.GetAbsOrigin(hero)
-    local enemies = collect_enemies(hero, search_radius)
-    local closest, best_distance = nil, math.huge
+    if not hero_pos then
+        return nil
+    end
+
+    local closest_enemy
+    local closest_distance = math.huge
+
     for _, enemy in ipairs(enemies) do
-        local enemy_pos = Entity.GetAbsOrigin(enemy)
-        local distance = hero_pos:Distance(enemy_pos)
-        if distance < best_distance then
-            best_distance = distance
-            closest = enemy
-        end
-    end
-    return closest, best_distance
-end
-
-local function find_enemy_for_ability(hero, ability, def)
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    local cast_range = def.cast_range_override or Ability.GetCastRange(ability)
-    if not cast_range or cast_range <= 0 then
-        cast_range = 600
-    end
-    local bonus = NPC.GetCastRangeBonus(hero) or 0
-    cast_range = cast_range + bonus + 50
-    local search_radius = math.max(cast_range, ui.enemy_range:Get())
-    local enemies = collect_enemies(hero, search_radius)
-    local best_enemy, best_distance = nil, math.huge
-    for _, enemy in ipairs(enemies) do
-        local enemy_pos = Entity.GetAbsOrigin(enemy)
-        local distance = hero_pos:Distance(enemy_pos)
-        if distance <= cast_range and distance < best_distance then
-            best_distance = distance
-            best_enemy = enemy
-        end
-    end
-    return best_enemy, best_distance
-end
-
-local function compute_escape_position(hero, enemy, distance)
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    local direction
-    if enemy then
-        local enemy_pos = Entity.GetAbsOrigin(enemy)
-        direction = hero_pos - enemy_pos
-    else
-        local forward = Entity.GetForwardPosition(hero, 10)
-        direction = hero_pos - forward
-    end
-    if math.abs(direction.x) < 0.001 and math.abs(direction.y) < 0.001 then
-        direction = Vector(1, 0, 0)
-    end
-    direction.z = 0
-    local normalized = direction:Normalized()
-    local target = hero_pos + normalized:Scaled(distance)
-    target.z = hero_pos.z
-    return target
-end
-
-local function can_cast_now(def, hero, ability, detection_enemies)
-    if def.modifier and NPC.HasModifier(hero, def.modifier) then
-        return false
-    end
-    if def.requires_charges and not item_has_charges(ability) then
-        return false
-    end
-    if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
-        return false
-    end
-    if def.enemy_toggle then
-        local toggle = ui.items[def.id].requires_enemy
-        if toggle and toggle:Get() and (#detection_enemies == 0) then
-            return false
-        end
-    end
-    return true
-end
-
-local function build_priority_queue()
-    local queue = {}
-    for _, def in ipairs(ITEM_DEFINITIONS) do
-        local widgets = ui.items[def.id]
-        if widgets and widgets.enabled:Get() then
-            table.insert(queue, {
-                def = def,
-                order = widgets.priority:Get(),
-            })
-        end
-    end
-    table.sort(queue, function(a, b)
-        if a.order == b.order then
-            return a.def.id < b.def.id
-        end
-        return a.order < b.order
-    end)
-    return queue
-end
---#endregion
-
---#region Pending escape handling
-local pending_escapes = {}
-local pending_eul_blink = nil
-
-local function clear_pending(def_id)
-    if def_id then
-        pending_escapes[def_id] = nil
-        if pending_eul_blink and pending_eul_blink.def and pending_eul_blink.def.id == def_id then
-            pending_eul_blink = nil
-        end
-        return
-    end
-    for key in pairs(pending_escapes) do
-        pending_escapes[key] = nil
-    end
-    pending_eul_blink = nil
-end
-
-local function find_ready_blink(hero, detection_enemies)
-    local current_health = health_percent(hero)
-    for _, id in ipairs(BLINK_ITEM_IDS) do
-        local def = ITEM_BY_ID[id]
-        if def then
-            local widgets = ui.items[def.id]
-            if widgets and widgets.enabled:Get() then
-                local ability = find_item(hero, def.ability_names)
-                if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
-                    if not widgets.threshold or current_health <= widgets.threshold:Get() then
-                        return def, ability
+        if enemy and Entity.IsAlive(enemy) and not NPC.IsIllusion(enemy) then
+            if not definition.enemy_modifier or not NPC.HasModifier(enemy, definition.enemy_modifier) then
+                local enemy_pos = Entity.GetAbsOrigin(enemy)
+                if enemy_pos then
+                    local distance = hero_pos:Distance2D(enemy_pos)
+                    if distance < closest_distance then
+                        closest_distance = distance
+                        closest_enemy = enemy
                     end
                 end
             end
         end
     end
-    return nil, nil
+
+    return closest_enemy
 end
 
-local function queue_blink_after_eul(eul_def, hero, detection_enemies)
-    local blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
-    if not blink_def or not blink_ability then
-        return false
+local function find_closest_enemy(hero, range)
+    if range <= 0 then
+        return nil
     end
-    local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
-    if not enemy then
-        return false
+
+    local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
+    if not enemies or #enemies == 0 then
+        return nil
     end
-    local distance = blink_def.blink_range or 1200
-    local escape_position = compute_escape_position(hero, enemy, distance)
-    pending_eul_blink = {
-        def = blink_def,
-        ability = blink_ability,
-        enemy = enemy,
-        escape_position = escape_position,
-        distance = distance,
-        wait_modifier = eul_def and eul_def.modifier or "modifier_eul_cyclone",
-        expire_time = GameRules.GetGameTime() + 3.5,
-    }
-    return true
+
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil
+    end
+
+    local closest_enemy
+    local closest_distance = math.huge
+
+    for _, enemy in ipairs(enemies) do
+        if enemy and Entity.IsAlive(enemy) and not NPC.IsIllusion(enemy) then
+            local enemy_pos = Entity.GetAbsOrigin(enemy)
+            if enemy_pos then
+                local distance = hero_pos:Distance2D(enemy_pos)
+                if distance < closest_distance then
+                    closest_distance = distance
+                    closest_enemy = enemy
+                end
+            end
+        end
+    end
+
+    return closest_enemy
 end
 
-local function queue_force_escape(def, hero, ability, closest_enemy)
-    if pending_escapes[def.id] then
-        return true
+local function normalize_flat_vector(vector)
+    if not vector then
+        return nil
     end
-    if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
-        return false
+
+    local length = vector:Length2D()
+    if length <= 0 then
+        return nil
     end
-    local distance = def.escape_distance or 600
-    local escape_position = compute_escape_position(hero, closest_enemy, distance)
+
+    vector.x = vector.x / length
+    vector.y = vector.y / length
+    vector.z = 0
+
+    return vector
+end
+
+local function face_direction(hero, direction)
+    if not hero or not direction then
+        return
+    end
+
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return
+    end
+
+    if not Players or not Player or not Player.PrepareUnitOrders or not Players.GetLocal then
+        return
+    end
+
     local player = Players.GetLocal()
-    if player then
-        Player.PrepareUnitOrders(
-            player,
-            Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION,
-            nil,
-            escape_position,
-            nil,
-            Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_HERO_ONLY,
-            hero,
-            false,
-            false,
-            nil,
-            true
-        )
+    if not player then
+        return
     end
-    local delay = (ui.escape_turn_delay:Get() or 0) / 1000
-    pending_escapes[def.id] = {
-        ability = ability,
-        ability_index = Ability.GetIndex(ability),
-        execute_time = GameRules.GetGameTime() + delay,
-        threshold_widget = ui.items[def.id].threshold,
-    }
-    return true
+
+    local move_target = hero_pos + direction * 50
+    move_target.z = hero_pos.z
+    Player.PrepareUnitOrders(
+        player,
+        Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION,
+        nil,
+        move_target,
+        nil,
+        Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_HERO_ONLY,
+        hero,
+        false,
+        false
+    )
 end
 
-local function process_pending_escapes(hero, detection_enemies)
-    for def_id, entry in pairs(pending_escapes) do
-        local def = ITEM_BY_ID[def_id]
-        if not def then
-            pending_escapes[def_id] = nil
-        else
-            if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
-                pending_escapes[def_id] = nil
-            else
-                local threshold = entry.threshold_widget and entry.threshold_widget:Get() or def.threshold_default or 0
-                if health_percent(hero) > threshold then
-                    pending_escapes[def_id] = nil
-                elseif def.enemy_toggle then
-                    local toggle = ui.items[def.id].requires_enemy
-                    if toggle and toggle:Get() and (#detection_enemies == 0) then
-                        pending_escapes[def_id] = nil
-                    end
-                end
-            end
-        end
+local function get_escape_direction(hero, ability, definition)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil, nil
     end
 
-    local current_time = GameRules.GetGameTime()
-    for def_id, entry in pairs(pending_escapes) do
-        local def = ITEM_BY_ID[def_id]
-        if not def then
-            pending_escapes[def_id] = nil
-        else
-            if current_time >= entry.execute_time then
-                if NPC.IsChannellingAbility(hero) then
-                    entry.execute_time = current_time + 0.05
-                else
-                    if ability_is_valid(hero, entry.ability) then
-                        Ability.CastTarget(entry.ability, hero)
-                    end
-                    pending_escapes[def_id] = nil
-                end
-            end
-        end
+    local search_range = definition and definition.search_range or DEFAULT_SEARCH_RANGE
+    if ability then
+        search_range = math.max(search_range, get_effective_cast_range(hero, ability, definition))
     end
+
+    local enemy = find_closest_enemy(hero, search_range)
+    if not enemy then
+        return nil, nil
+    end
+
+    local enemy_pos = Entity.GetAbsOrigin(enemy)
+    if not enemy_pos then
+        return nil, nil
+    end
+
+    local direction = hero_pos - enemy_pos
+    direction = normalize_flat_vector(direction)
+
+    if not direction then
+        return nil, nil
+    end
+
+    return direction, enemy
 end
 
-local function process_pending_eul_blink(hero, detection_enemies)
-    if not pending_eul_blink then
-        return
-    end
-    local entry = pending_eul_blink
-    local blink_def = entry.def
-    if not blink_def then
-        pending_eul_blink = nil
-        return
-    end
-    local widgets = ui.items[blink_def.id]
-    if not widgets or not widgets.enabled:Get() then
-        pending_eul_blink = nil
-        return
-    end
-    local current_health = health_percent(hero)
-    if widgets.threshold and current_health > widgets.threshold:Get() then
-        pending_eul_blink = nil
-        return
-    end
-    if entry.wait_modifier and NPC.HasModifier(hero, entry.wait_modifier) then
-        if entry.expire_time and GameRules.GetGameTime() > entry.expire_time then
-            pending_eul_blink = nil
-        end
-        return
-    end
-    if NPC.IsChannellingAbility(hero) then
-        return
-    end
-    if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
-        pending_eul_blink = nil
-        return
-    end
-    if not ability_is_valid(hero, entry.ability) then
-        pending_eul_blink = nil
-        return
-    end
-    if not can_cast_now(blink_def, hero, entry.ability, detection_enemies) then
-        pending_eul_blink = nil
-        return
-    end
-    local enemy = entry.enemy
-    if not enemy or not Entity.IsAlive(enemy) or Entity.IsDormant(enemy) or NPC.IsIllusion(enemy) then
-        enemy = find_closest_enemy(hero, ui.enemy_range:Get())
-    end
-    local cast_position = entry.escape_position
-    if enemy then
-        cast_position = compute_escape_position(hero, enemy, entry.distance or blink_def.blink_range or 1200)
-    end
-    if not cast_position then
-        pending_eul_blink = nil
-        return
-    end
-    Ability.CastPosition(entry.ability, cast_position)
-    pending_eul_blink = nil
-end
---#endregion
+local ESCAPE_TURN_DELAY = 0.2
+local pending_escape_casts = {}
 
---#region Casting logic
-local function cast_eul_combo(def, hero, ability, detection_enemies)
-    Ability.CastTarget(ability, hero)
-    queue_blink_after_eul(def, hero, detection_enemies)
-    return true
+local function clear_pending_escape(item_key)
+    pending_escape_casts[item_key] = nil
 end
 
-local function cast_meteor_combo(def, hero, ability, detection_enemies)
-    local glimmer_def = ITEM_BY_ID.glimmer
-    if not glimmer_def then
-        return false
-    end
-    local glimmer_widgets = ui.items[glimmer_def.id]
-    if not glimmer_widgets or not glimmer_widgets.enabled:Get() then
-        return false
-    end
-
-    local glimmer_threshold = glimmer_widgets.threshold and glimmer_widgets.threshold:Get() or glimmer_def.threshold_default or 50
-    if health_percent(hero) > glimmer_threshold then
-        return false
-    end
-
-    local casted_glimmer = false
-    local glimmer = find_item(hero, glimmer_def.ability_names)
-    if glimmer and ability_is_valid(hero, glimmer) and can_cast_now(glimmer_def, hero, glimmer, detection_enemies) then
-        Ability.CastTarget(glimmer, hero)
-        casted_glimmer = true
-    end
-
-    if not casted_glimmer then
-        if not (glimmer_def.modifier and NPC.HasModifier(hero, glimmer_def.modifier)) then
-            return false
-        end
-    end
-
-    local target = find_enemy_for_ability(hero, ability, def)
-    if not target then
-        return false
-    end
-    local enemy_pos = Entity.GetAbsOrigin(target)
-    Ability.CastPosition(ability, enemy_pos)
-    return true
-end
-
-local function cast_item(def, hero, detection_enemies)
-    local ability = find_item(hero, def.ability_names)
-    if not ability then
-        return false
-    end
-    if not ability_is_valid(hero, ability) then
-        return false
-    end
-    if not can_cast_now(def, hero, ability, detection_enemies) then
-        return false
-    end
-
-    if def.cast == "target_self" then
-        Ability.CastTarget(ability, hero)
+local function needs_new_escape(direction, enemy, pending)
+    if not pending then
         return true
-    elseif def.cast == "no_target" then
-        Ability.CastNoTarget(ability)
-        return true
-    elseif def.cast == "target_enemy" then
-        local enemy = find_enemy_for_ability(hero, ability, def)
-        if not enemy then
-            return false
-        end
-        Ability.CastTarget(ability, enemy)
-        return true
-    elseif def.cast == "position_enemy" then
-        local enemy = find_enemy_for_ability(hero, ability, def)
-        if not enemy then
-            return false
-        end
-        local enemy_pos = Entity.GetAbsOrigin(enemy)
-        Ability.CastPosition(ability, enemy_pos)
-        return true
-    elseif def.cast == "blink_escape" then
-        if pending_eul_blink then
-            return false
-        end
-        local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
-        if not enemy then
-            return false
-        end
-        local blink_distance = def.blink_range or 1200
-        local escape_position = compute_escape_position(hero, enemy, blink_distance)
-        Ability.CastPosition(ability, escape_position)
-        return true
-    elseif def.cast == "force_escape" then
-        local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
-        if not enemy then
-            return false
-        end
-        return queue_force_escape(def, hero, ability, enemy)
-    elseif def.cast == "eul_combo" then
-        return cast_eul_combo(def, hero, ability, detection_enemies)
-    elseif def.cast == "meteor_combo" then
-        return cast_meteor_combo(def, hero, ability, detection_enemies)
     end
+
+    if pending.enemy ~= enemy then
+        return true
+    end
+
+    local pending_dir = pending.direction
+    if not pending_dir or not direction then
+        return true
+    end
+
+    local dot = pending_dir.x * direction.x + pending_dir.y * direction.y
+    if dot < 0.95 then
+        return true
+    end
+
     return false
 end
---#endregion
+
+local function cast_item(hero, item_key, game_time)
+    local definition = ITEM_DEFINITIONS[item_key]
+    if not definition then
+        return false
+    end
+
+    if is_recently_cast(item_key, game_time) then
+        return false
+    end
+
+    local item = get_inventory_item(hero, definition)
+    if not item then
+        return false
+    end
+
+    if definition.modifier and NPC.HasModifier(hero, definition.modifier) then
+        return false
+    end
+
+    if not Ability.IsReady(item) then
+        return false
+    end
+
+    if definition.requires_charges then
+        local charges = Ability.GetCurrentCharges(item)
+        if not charges or charges <= 0 then
+            return false
+        end
+    end
+
+    local mana = NPC.GetMana(hero)
+    if not Ability.IsCastable(item, mana) then
+        return false
+    end
+
+    if not can_use_item(hero) then
+        return false
+    end
+
+    if definition.requires_enemy then
+        local range = get_effective_cast_range(hero, item, definition)
+        local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
+        if not enemies or #enemies == 0 then
+            return false
+        end
+    end
+
+    if definition.type == "no_target" then
+        Ability.CastNoTarget(item)
+    elseif definition.type == "target_self" then
+        Ability.CastTarget(item, hero)
+    elseif definition.type == "target_enemy" then
+        local target = find_enemy_target(hero, item, definition)
+        if not target then
+            return false
+        end
+
+        Ability.CastTarget(item, target)
+    elseif definition.type == "position_enemy" then
+        local target = find_enemy_target(hero, item, definition)
+        if not target then
+            return false
+        end
+
+        local target_pos = Entity.GetAbsOrigin(target)
+        if not target_pos then
+            return false
+        end
+
+        Ability.CastPosition(item, target_pos)
+    elseif definition.type == "escape_self" then
+        local direction, enemy = get_escape_direction(hero, item, definition)
+        if not direction then
+            clear_pending_escape(item_key)
+            return false
+        end
+
+        local pending = pending_escape_casts[item_key]
+
+        if needs_new_escape(direction, enemy, pending) then
+            pending_escape_casts[item_key] = {
+                ready_time = game_time + ESCAPE_TURN_DELAY,
+                direction = direction,
+                enemy = enemy,
+            }
+            face_direction(hero, direction)
+            return false
+        end
+
+        pending.direction = direction
+
+        if game_time < pending.ready_time then
+            face_direction(hero, pending.direction)
+            return false
+        end
+
+        face_direction(hero, pending.direction)
+        Ability.CastTarget(item, hero)
+        clear_pending_escape(item_key)
+    elseif definition.type == "escape_position" then
+        local direction = get_escape_direction(hero, item, definition)
+        if not direction then
+            return false
+        end
+
+        local hero_pos = Entity.GetAbsOrigin(hero)
+        if not hero_pos then
+            return false
+        end
+
+        local distance = definition.escape_distance or get_effective_cast_range(hero, item, definition)
+        if distance <= 0 then
+            distance = 1150
+        end
+
+        local cast_position = hero_pos + direction * distance
+        cast_position.z = hero_pos.z
+
+        Ability.CastPosition(item, cast_position)
+    else
+        return false
+    end
+
+    mark_cast(item_key, game_time)
+
+    return true
+end
 
 function auto_defender.OnUpdate()
+    if not Engine.IsInGame() then
+        last_cast_times = {}
+        pending_escape_casts = {}
+        return
+    end
+
     if not ui.enable:Get() then
-        clear_pending()
         return
     end
 
-    local hero = get_local_hero()
-    if not hero then
-        clear_pending()
+    local hero = Heroes.GetLocal()
+    if not hero or NPC.IsIllusion(hero) or not Entity.IsAlive(hero) or Entity.IsDormant(hero) then
+        pending_escape_casts = {}
         return
     end
 
-    local current_health = health_percent(hero)
-    local detection_enemies = collect_enemies(hero, ui.enemy_range:Get())
-
-    process_pending_escapes(hero, detection_enemies)
-    process_pending_eul_blink(hero, detection_enemies)
-
-    if NPC.IsChannellingAbility(hero) then
-        -- allow only items that explicitly opt-in
-        local queue = build_priority_queue()
-        for _, item in ipairs(queue) do
-            local def = item.def
-            if def.allow_while_channeling then
-                local widgets = ui.items[def.id]
-                if widgets then
-                    local should_cast = true
-                    if widgets.threshold then
-                        should_cast = current_health <= widgets.threshold:Get()
-                    end
-                    if should_cast then
-                        cast_item(def, hero, detection_enemies)
-                    end
-                end
-            end
-        end
+    local max_health = Entity.GetMaxHealth(hero)
+    if max_health <= 0 then
         return
     end
 
-    local queue = build_priority_queue()
-    for _, item in ipairs(queue) do
-        local def = item.def
-        local widgets = ui.items[def.id]
-        if widgets then
-            local should_cast = true
-            if widgets.threshold then
-                should_cast = current_health <= widgets.threshold:Get()
-            end
-            if should_cast then
-                cast_item(def, hero, detection_enemies)
-            end
+    local current_health = Entity.GetHealth(hero)
+    local health_percent = (current_health / max_health) * 100.0
+
+    local game_time = GameRules.GetGameTime()
+    local items_to_use = get_enabled_items()
+
+    if #items_to_use == 0 then
+        return
+    end
+
+    for _, key in ipairs(items_to_use) do
+        local threshold_slider = item_thresholds[key]
+        if threshold_slider and health_percent <= threshold_slider:Get() then
+            cast_item(hero, key, game_time)
         end
     end
 end
 
 function auto_defender.OnGameEnd()
-    clear_pending()
+    last_cast_times = {}
+    pending_escape_casts = {}
 end
 
 return auto_defender

--- a/script.lua
+++ b/script.lua
@@ -2,8 +2,17 @@
 
 local auto_defender = {}
 
-local tab = Menu.Create("General", "Auto Defender", "Auto Defender", "Auto Defender")
-local info_group = tab:Create("Info", 0)
+--#region UI setup
+local MAIN_FIRST_TAB = "General"
+local MAIN_SECTION = "Auto Defender"
+
+local overview_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, "Overview")
+local overview_page = overview_tab:Create("Overview")
+
+local info_group = overview_page:Create("Info")
+local activation_group = overview_page:Create("Activation")
+local detection_group = overview_page:Create("Enemy Detection")
+
 if info_group.Label then
     info_group:Label("Author: GhostyPowa")
 elseif info_group.Text then
@@ -21,342 +30,523 @@ else
     end
 end
 
-local activation_group = tab:Create("Activation")
-local priority_group = tab:Create("Item Priority", 1)
-local threshold_group = tab:Create("Item Thresholds", 2)
+local function create_section_tab(second_name, third_name)
+    local second_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, second_name)
+    local third_tab = second_tab:Create(third_name or second_name)
+    local toggles = third_tab:Create("Toggles")
+    local priority = third_tab:Create("Priority")
+    local thresholds = third_tab:Create("Thresholds")
+    local enemy_checks = third_tab:Create("Enemy Checks")
+    if priority.Label then
+        priority:Label("Lower value means higher priority")
+    end
+    return {
+        toggles = toggles,
+        priority = priority,
+        thresholds = thresholds,
+        enemy = enemy_checks,
+    }
+end
+
+local section_groups = {
+    defensive = create_section_tab("Defensive", "Defensive Items"),
+    escape = create_section_tab("Escape", "Escape Tools"),
+    utility = create_section_tab("Utility", "Utility Combos"),
+    offensive = create_section_tab("Offensive", "Offensive Items"),
+}
 
 local ui = {
     enable = activation_group:Switch("Enable", true),
+    enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
+    items = {},
 }
+--#endregion
 
+--#region Item definitions
 local ITEM_DEFINITIONS = {
-    glimmer = {
-        item_name = "item_glimmer_cape",
-        icon = "panorama/images/items/glimmer_cape_png.vtex_c",
+    {
+        id = "glimmer",
         display_name = "Glimmer Cape",
-        type = "target_self",
+        icon = "panorama/images/items/glimmer_cape_png.vtex_c",
+        ability_names = { "item_glimmer_cape" },
+        cast = "target_self",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_glimmer_cape_fade",
+        category = "defensive",
     },
-    ghost = {
-        item_name = "item_ghost",
-        icon = "panorama/images/items/ghost_scepter_png.vtex_c",
+    {
+        id = "ghost",
         display_name = "Ghost Scepter",
-        type = "no_target",
+        icon = "panorama/images/items/ghost_scepter_png.vtex_c",
+        ability_names = { "item_ghost" },
+        cast = "no_target",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_ghost_state",
+        category = "defensive",
     },
-    bkb = {
-        item_name = "item_black_king_bar",
-        icon = "panorama/images/items/black_king_bar_png.vtex_c",
+    {
+        id = "bkb",
         display_name = "Black King Bar",
-        type = "no_target",
+        icon = "panorama/images/items/black_king_bar_png.vtex_c",
+        ability_names = { "item_black_king_bar" },
+        cast = "no_target",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_black_king_bar_immune",
+        category = "defensive",
     },
-    lotus = {
-        item_name = "item_lotus_orb",
-        icon = "panorama/images/items/lotus_orb_png.vtex_c",
+    {
+        id = "lotus",
         display_name = "Lotus Orb",
-        type = "target_self",
+        icon = "panorama/images/items/lotus_orb_png.vtex_c",
+        ability_names = { "item_lotus_orb" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_lotus_orb_active",
+        category = "defensive",
     },
-    crimson = {
-        item_name = "item_crimson_guard",
-        icon = "panorama/images/items/crimson_guard_png.vtex_c",
+    {
+        id = "crimson",
         display_name = "Crimson Guard",
-        type = "no_target",
+        icon = "panorama/images/items/crimson_guard_png.vtex_c",
+        ability_names = { "item_crimson_guard" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_crimson_guard_extra",
+        category = "defensive",
     },
-    blade_mail = {
-        item_name = "item_blade_mail",
-        icon = "panorama/images/items/blade_mail_png.vtex_c",
+    {
+        id = "blade_mail",
         display_name = "Blade Mail",
-        type = "no_target",
+        icon = "panorama/images/items/blade_mail_png.vtex_c",
+        ability_names = { "item_blade_mail" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_blade_mail_reflect",
+        category = "defensive",
     },
-    eul = {
-        item_name = "item_cyclone",
-        icon = "panorama/images/items/cyclone_png.vtex_c",
-        display_name = "Eul's Scepter",
-        type = "target_self",
-        modifier = "modifier_eul_cyclone",
+    {
+        id = "solar_crest",
+        display_name = "Solar Crest",
+        icon = "panorama/images/items/solar_crest_png.vtex_c",
+        ability_names = { "item_solar_crest" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_solar_crest_armor_addition",
+        category = "defensive",
     },
-    wind_waker = {
-        item_name = "item_wind_waker",
-        icon = "panorama/images/items/wind_waker_png.vtex_c",
-        display_name = "Wind Waker",
-        type = "target_self",
-        modifier = "modifier_item_wind_waker",
+    {
+        id = "drums",
+        display_name = "Drum of Endurance",
+        icon = "panorama/images/items/ancient_janggo_png.vtex_c",
+        ability_names = { "item_ancient_janggo" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
     },
-    force = {
-        item_name = "item_force_staff",
-        icon = "panorama/images/items/force_staff_png.vtex_c",
-        display_name = "Force Staff",
-        type = "escape_self",
-        modifier = "modifier_item_forcestaff_active",
-        search_range = 1600,
+    {
+        id = "boots_of_bearing",
+        display_name = "Boots of Bearing",
+        icon = "panorama/images/items/boots_of_bearing_png.vtex_c",
+        ability_names = { "item_boots_of_bearing" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
     },
-    hurricane = {
-        item_name = "item_hurricane_pike",
-        icon = "panorama/images/items/hurricane_pike_png.vtex_c",
-        display_name = "Hurricane Pike",
-        type = "escape_self",
-        modifier = "modifier_item_hurricane_pike",
-        search_range = 1600,
-    },
-    atos = {
-        item_name = "item_rod_of_atos",
-        icon = "panorama/images/items/rod_of_atos_png.vtex_c",
-        display_name = "Rod of Atos",
-        type = "target_enemy",
-        enemy_modifier = "modifier_rod_of_atos_debuff",
-        range = 1100,
-    },
-    hex = {
-        item_name = "item_sheepstick",
-        icon = "panorama/images/items/sheepstick_png.vtex_c",
-        display_name = "Scythe of Vyse",
-        type = "target_enemy",
-        enemy_modifier = "modifier_sheepstick_debuff",
-        range = 800,
-    },
-    abyssal = {
-        item_name = "item_abyssal_blade",
-        icon = "panorama/images/items/abyssal_blade_png.vtex_c",
-        display_name = "Abyssal Blade",
-        type = "target_enemy",
-        enemy_modifier = "modifier_abyssal_blade_debuff",
-        range = 600,
-    },
-    diffusal = {
-        item_name = "item_diffusal_blade",
-        icon = "panorama/images/items/diffusal_blade_png.vtex_c",
-        display_name = "Diffusal Blade",
-        type = "target_enemy",
-        enemy_modifier = "modifier_item_diffusal_blade_slow",
-        range = 600,
-    },
-    gleipnir = {
-        item_name = "item_gleipnir",
-        icon = "panorama/images/items/gleipnir_png.vtex_c",
-        display_name = "Gleipnir",
-        type = "position_enemy",
-        enemy_modifier = "modifier_gleipnir_root",
-        range = 1100,
-    },
-    bloodthorn = {
-        item_name = "item_bloodthorn",
-        icon = "panorama/images/items/bloodthorn_png.vtex_c",
-        display_name = "Bloodthorn",
-        type = "target_enemy",
-        enemy_modifier = "modifier_bloodthorn_debuff",
-        range = 900,
-    },
-    silver = {
-        item_name = "item_silver_edge",
-        icon = "panorama/images/items/silver_edge_png.vtex_c",
-        display_name = "Silver Edge",
-        type = "no_target",
-        modifier = "modifier_item_silver_edge_windwalk",
-        requires_enemy = true,
-        search_range = 1200,
-    },
-    shadow_blade = {
-        item_name = "item_invis_sword",
-        icon = "panorama/images/items/invis_sword_png.vtex_c",
-        display_name = "Shadow Blade",
-        type = "no_target",
-        modifier = "modifier_item_invis_sword_windwalk",
-        requires_enemy = true,
-        search_range = 1200,
-    },
-    disperser = {
-        item_name = "item_disperser",
-        icon = "panorama/images/items/disperser_png.vtex_c",
-        display_name = "Disperser",
-        type = "target_self",
-        modifier = "modifier_item_disperser_active",
-    },
-    pipe = {
-        item_name = "item_pipe",
-        icon = "panorama/images/items/pipe_png.vtex_c",
+    {
+        id = "pipe",
         display_name = "Pipe of Insight",
-        type = "no_target",
+        icon = "panorama/images/items/pipe_png.vtex_c",
+        ability_names = { "item_pipe" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_pipe_barrier",
+        category = "defensive",
     },
-    ethereal = {
-        item_name = "item_ethereal_blade",
-        icon = "panorama/images/items/ethereal_blade_png.vtex_c",
+    {
+        id = "disperser",
+        display_name = "Disperser",
+        icon = "panorama/images/items/disperser_png.vtex_c",
+        ability_names = { "item_disperser" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_disperser_active",
+        category = "defensive",
+    },
+    {
+        id = "ethereal",
         display_name = "Ethereal Blade",
-        type = "target_self",
+        icon = "panorama/images/items/ethereal_blade_png.vtex_c",
+        ability_names = { "item_ethereal_blade" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
         modifier = "modifier_item_ethereal_blade_ethereal",
+        category = "defensive",
     },
-    nullifier = {
-        item_name = "item_nullifier",
-        icon = "panorama/images/items/nullifier_png.vtex_c",
+    {
+        id = "urn",
+        display_name = "Urn of Shadows",
+        icon = "panorama/images/items/urn_of_shadows_png.vtex_c",
+        ability_names = { "item_urn_of_shadows" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        modifier = "modifier_item_urn_heal",
+        category = "defensive",
+    },
+    {
+        id = "spirit_vessel",
+        display_name = "Spirit Vessel",
+        icon = "panorama/images/items/spirit_vessel_png.vtex_c",
+        ability_names = { "item_spirit_vessel" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        modifier = "modifier_item_spirit_vessel_heal",
+        category = "defensive",
+    },
+    {
+        id = "eul",
+        display_name = "Eul's Scepter",
+        icon = "panorama/images/items/cyclone_png.vtex_c",
+        ability_names = { "item_cyclone" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_eul_cyclone",
+        category = "utility",
+    },
+    {
+        id = "wind_waker",
+        display_name = "Wind Waker",
+        icon = "panorama/images/items/wind_waker_png.vtex_c",
+        ability_names = { "item_wind_waker" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_wind_waker",
+        category = "utility",
+    },
+    {
+        id = "meteor",
+        display_name = "Meteor Hammer",
+        icon = "panorama/images/items/meteor_hammer_png.vtex_c",
+        ability_names = { "item_meteor_hammer" },
+        cast = "meteor_combo",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "utility",
+    },
+    {
+        id = "force",
+        display_name = "Force Staff",
+        icon = "panorama/images/items/force_staff_png.vtex_c",
+        ability_names = { "item_force_staff" },
+        cast = "escape_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "escape",
+    },
+    {
+        id = "hurricane",
+        display_name = "Hurricane Pike",
+        icon = "panorama/images/items/hurricane_pike_png.vtex_c",
+        ability_names = { "item_hurricane_pike" },
+        cast = "escape_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "escape",
+    },
+    {
+        id = "blink",
+        display_name = "Blink Dagger",
+        icon = "panorama/images/items/blink_png.vtex_c",
+        ability_names = { "item_blink" },
+        cast = "escape_position",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "overwhelming_blink",
+        display_name = "Overwhelming Blink",
+        icon = "panorama/images/items/overwhelming_blink_png.vtex_c",
+        ability_names = { "item_overwhelming_blink" },
+        cast = "escape_position",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "swift_blink",
+        display_name = "Swift Blink",
+        icon = "panorama/images/items/swift_blink_png.vtex_c",
+        ability_names = { "item_swift_blink" },
+        cast = "escape_position",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "arcane_blink",
+        display_name = "Arcane Blink",
+        icon = "panorama/images/items/arcane_blink_png.vtex_c",
+        ability_names = { "item_arcane_blink" },
+        cast = "escape_position",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "atos",
+        display_name = "Rod of Atos",
+        icon = "panorama/images/items/rod_of_atos_png.vtex_c",
+        ability_names = { "item_rod_of_atos" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 1100,
+        category = "offensive",
+    },
+    {
+        id = "hex",
+        display_name = "Scythe of Vyse",
+        icon = "panorama/images/items/sheepstick_png.vtex_c",
+        ability_names = { "item_sheepstick" },
+        cast = "target_enemy",
+        threshold_default = 40,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "offensive",
+    },
+    {
+        id = "abyssal",
+        display_name = "Abyssal Blade",
+        icon = "panorama/images/items/abyssal_blade_png.vtex_c",
+        ability_names = { "item_abyssal_blade" },
+        cast = "target_enemy",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "diffusal",
+        display_name = "Diffusal Blade",
+        icon = "panorama/images/items/diffusal_blade_png.vtex_c",
+        ability_names = { "item_diffusal_blade", "item_diffusal_blade_2" },
+        cast = "target_enemy",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "gleipnir",
+        display_name = "Gleipnir",
+        icon = "panorama/images/items/gleipnir_png.vtex_c",
+        ability_names = { "item_gleipnir" },
+        cast = "position_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 1100,
+        category = "offensive",
+    },
+    {
+        id = "bloodthorn",
+        display_name = "Bloodthorn",
+        icon = "panorama/images/items/bloodthorn_png.vtex_c",
+        ability_names = { "item_bloodthorn" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "orchid",
+        display_name = "Orchid Malevolence",
+        icon = "panorama/images/items/orchid_png.vtex_c",
+        ability_names = { "item_orchid" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "nullifier",
         display_name = "Nullifier",
-        type = "target_enemy",
-        enemy_modifier = "modifier_item_nullifier_mute",
-        range = 900,
+        icon = "panorama/images/items/nullifier_png.vtex_c",
+        ability_names = { "item_nullifier" },
+        cast = "target_enemy",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
     },
-    dagon = {
-        item_names = {
+    {
+        id = "dagon",
+        display_name = "Dagon",
+        icon = "panorama/images/items/dagon_png.vtex_c",
+        ability_names = {
             "item_dagon",
             "item_dagon_2",
             "item_dagon_3",
             "item_dagon_4",
             "item_dagon_5",
         },
-        icon = "panorama/images/items/dagon_png.vtex_c",
-        display_name = "Dagon",
-        type = "target_enemy",
-        range = 900,
+        cast = "target_enemy",
+        threshold_default = 60,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "offensive",
     },
-    blood_grenade = {
-        item_name = "item_blood_grenade",
-        icon = "panorama/images/items/blood_grenade_png.vtex_c",
+    {
+        id = "blood_grenade",
         display_name = "Blood Grenade",
-        type = "position_enemy",
-        enemy_modifier = "modifier_item_blood_grenade_slow",
-        range = 900,
+        icon = "panorama/images/items/blood_grenade_png.vtex_c",
+        ability_names = { "item_blood_grenade" },
+        cast = "position_enemy",
+        threshold_default = 60,
+        enemy_toggle = true,
+        enemy_required_default = true,
         requires_charges = true,
+        cast_range_override = 900,
+        category = "offensive",
     },
-    halberd = {
-        item_name = "item_heavens_halberd",
-        icon = "panorama/images/items/heavens_halberd_png.vtex_c",
+    {
+        id = "halberd",
         display_name = "Heaven's Halberd",
-        type = "target_enemy",
-        enemy_modifier = "modifier_heavens_halberd_debuff",
-        range = 600,
+        icon = "panorama/images/items/heavens_halberd_png.vtex_c",
+        ability_names = { "item_heavens_halberd" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
     },
-    urn = {
-        item_name = "item_urn_of_shadows",
-        icon = "panorama/images/items/urn_of_shadows_png.vtex_c",
-        display_name = "Urn of Shadows",
-        type = "target_self",
-        modifier = "modifier_item_urn_heal",
-        requires_charges = true,
+    {
+        id = "silver",
+        display_name = "Silver Edge",
+        icon = "panorama/images/items/silver_edge_png.vtex_c",
+        ability_names = { "item_silver_edge" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_enemy = true,
+        cast_range_override = 1200,
+        category = "offensive",
     },
-    spirit_vessel = {
-        item_name = "item_spirit_vessel",
-        icon = "panorama/images/items/spirit_vessel_png.vtex_c",
-        display_name = "Spirit Vessel",
-        type = "target_self",
-        modifier = "modifier_item_spirit_vessel_heal",
-        requires_charges = true,
-    },
-    blink = {
-        item_name = "item_blink",
-        icon = "panorama/images/items/blink_png.vtex_c",
-        display_name = "Blink Dagger",
-        type = "escape_position",
-        range = 1200,
-        escape_distance = 1150,
-    },
-    overwhelming_blink = {
-        item_name = "item_overwhelming_blink",
-        icon = "panorama/images/items/overwhelming_blink_png.vtex_c",
-        display_name = "Overwhelming Blink",
-        type = "escape_position",
-        range = 1200,
-        escape_distance = 1150,
-    },
-    swift_blink = {
-        item_name = "item_swift_blink",
-        icon = "panorama/images/items/swift_blink_png.vtex_c",
-        display_name = "Swift Blink",
-        type = "escape_position",
-        range = 1200,
-        escape_distance = 1150,
-    },
-    arcane_blink = {
-        item_name = "item_arcane_blink",
-        icon = "panorama/images/items/arcane_blink_png.vtex_c",
-        display_name = "Arcane Blink",
-        type = "escape_position",
-        range = 1200,
-        escape_distance = 1150,
-    },
-    solar_crest = {
-        item_name = "item_solar_crest",
-        icon = "panorama/images/items/solar_crest_png.vtex_c",
-        display_name = "Solar Crest",
-        type = "target_self",
-        modifier = "modifier_item_solar_crest_armor_addition",
-    },
-    drums = {
-        item_name = "item_ancient_janggo",
-        icon = "panorama/images/items/ancient_janggo_png.vtex_c",
-        display_name = "Drum of Endurance",
-        type = "no_target",
-        modifier = "modifier_item_ancient_janggo_active",
-    },
-    boots_of_bearing = {
-        item_name = "item_boots_of_bearing",
-        icon = "panorama/images/items/boots_of_bearing_png.vtex_c",
-        display_name = "Boots of Bearing",
-        type = "no_target",
-        modifier = "modifier_item_boots_of_bearing_active",
+    {
+        id = "shadow_blade",
+        display_name = "Shadow Blade",
+        icon = "panorama/images/items/shadow_blade_png.vtex_c",
+        ability_names = { "item_invis_sword" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_enemy = true,
+        cast_range_override = 1200,
+        category = "offensive",
     },
 }
 
-local priority_items = {
-    { "glimmer", ITEM_DEFINITIONS.glimmer.icon, true },
-    { "ghost", ITEM_DEFINITIONS.ghost.icon, true },
-    { "bkb", ITEM_DEFINITIONS.bkb.icon, true },
-    { "lotus", ITEM_DEFINITIONS.lotus.icon, false },
-    { "crimson", ITEM_DEFINITIONS.crimson.icon, false },
-    { "blade_mail", ITEM_DEFINITIONS.blade_mail.icon, false },
-    { "eul", ITEM_DEFINITIONS.eul.icon, false },
-    { "wind_waker", ITEM_DEFINITIONS.wind_waker.icon, false },
-    { "force", ITEM_DEFINITIONS.force.icon, false },
-    { "hurricane", ITEM_DEFINITIONS.hurricane.icon, false },
-    { "disperser", ITEM_DEFINITIONS.disperser.icon, false },
-    { "pipe", ITEM_DEFINITIONS.pipe.icon, false },
-    { "ethereal", ITEM_DEFINITIONS.ethereal.icon, false },
-    { "nullifier", ITEM_DEFINITIONS.nullifier.icon, false },
-    { "dagon", ITEM_DEFINITIONS.dagon.icon, false },
-    { "blood_grenade", ITEM_DEFINITIONS.blood_grenade.icon, false },
-    { "halberd", ITEM_DEFINITIONS.halberd.icon, false },
-    { "urn", ITEM_DEFINITIONS.urn.icon, false },
-    { "spirit_vessel", ITEM_DEFINITIONS.spirit_vessel.icon, false },
-    { "blink", ITEM_DEFINITIONS.blink.icon, false },
-    { "overwhelming_blink", ITEM_DEFINITIONS.overwhelming_blink.icon, false },
-    { "swift_blink", ITEM_DEFINITIONS.swift_blink.icon, false },
-    { "arcane_blink", ITEM_DEFINITIONS.arcane_blink.icon, false },
-    { "solar_crest", ITEM_DEFINITIONS.solar_crest.icon, false },
-    { "drums", ITEM_DEFINITIONS.drums.icon, false },
-    { "boots_of_bearing", ITEM_DEFINITIONS.boots_of_bearing.icon, false },
-    { "atos", ITEM_DEFINITIONS.atos.icon, false },
-    { "hex", ITEM_DEFINITIONS.hex.icon, false },
-    { "abyssal", ITEM_DEFINITIONS.abyssal.icon, false },
-    { "bloodthorn", ITEM_DEFINITIONS.bloodthorn.icon, false },
-    { "diffusal", ITEM_DEFINITIONS.diffusal.icon, false },
-    { "gleipnir", ITEM_DEFINITIONS.gleipnir.icon, false },
-    { "silver", ITEM_DEFINITIONS.silver.icon, false },
-    { "shadow_blade", ITEM_DEFINITIONS.shadow_blade.icon, false },
-}
+local ITEM_BY_ID = {}
+--#endregion
 
-local priority_widget = priority_group:MultiSelect("Items", priority_items, true)
-priority_widget:DragAllowed(true)
-priority_widget:ToolTip("Drag to reorder priority. Enable items you want to use.")
-
-local item_thresholds = {}
-
-for _, item in ipairs(priority_items) do
-    local key = item[1]
-    local definition = ITEM_DEFINITIONS[key]
-    if definition then
-        item_thresholds[key] = threshold_group:Slider(
-            definition.display_name,
-            1,
-            100,
-            50,
-            function(value)
-                return string.format("%d%%", value)
-            end
-        )
+local function apply_icon(widget, icon)
+    if not widget or not icon then
+        return
+    end
+    if widget.SetImage then
+        widget:SetImage(icon)
+    elseif widget.SetIcon then
+        widget:SetIcon(icon)
+    elseif widget.Image then
+        widget:Image(icon)
+    elseif widget.Icon then
+        widget:Icon(icon)
     end
 end
 
+for index, def in ipairs(ITEM_DEFINITIONS) do
+    ITEM_BY_ID[def.id] = def
+    local section = section_groups[def.category or "defensive"] or section_groups.defensive
+    local entry = {}
+    entry.enabled = section.toggles:Switch(def.display_name, true)
+    apply_icon(entry.enabled, def.icon)
+    entry.priority = section.priority:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
+    apply_icon(entry.priority, def.icon)
+    if not def.no_threshold then
+        entry.threshold = section.thresholds:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
+        apply_icon(entry.threshold, def.icon)
+    end
+    if def.enemy_toggle then
+        entry.requires_enemy = section.enemy:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
+        apply_icon(entry.requires_enemy, def.icon)
+    end
+    ui.items[def.id] = entry
+end
+
+--#region Helpers
 local CAST_COOLDOWN = 0.2
 local last_cast_times = {}
 
@@ -366,19 +556,219 @@ local CONTROL_BLOCKERS = {
     Enum.ModifierState.MODIFIER_STATE_MUTED,
 }
 
-local DEFAULT_SEARCH_RANGE = 1200
-
-local function can_use_item(hero)
+local function get_local_hero()
+    local hero = Heroes.GetLocal()
+    if not hero then
+        return nil
+    end
     if not Entity.IsAlive(hero) then
+        return nil
+    end
+    if Entity.IsDormant(hero) then
+        return nil
+    end
+    if NPC.IsIllusion(hero) then
+        return nil
+    end
+    return hero
+end
+
+local function health_percent(hero)
+    local health = Entity.GetHealth(hero)
+    local max_health = Entity.GetMaxHealth(hero)
+    if not max_health or max_health <= 0 then
+        return 100
+    end
+    return (health / max_health) * 100
+end
+
+local function find_item(hero, names)
+    for _, name in ipairs(names) do
+        local ability = NPC.GetItem(hero, name, true)
+        if ability then
+            return ability
+        end
+    end
+    return nil
+end
+
+local function ability_is_valid(hero, ability)
+    if not ability then
         return false
     end
+    if Ability.IsPassive(ability) then
+        return false
+    end
+    if Ability.IsHidden(ability) then
+        return false
+    end
+    if Ability.GetOwner(ability) ~= hero then
+        return false
+    end
+    if not Ability.IsActivated(ability) then
+        return false
+    end
+    if not Ability.IsReady(ability) then
+        return false
+    end
+    if not Ability.IsCastable(ability, NPC.GetMana(hero)) then
+        return false
+    end
+    return true
+end
 
+local function item_has_charges(ability)
+    if not ability then
+        return false
+    end
+    local charges = Ability.GetCurrentCharges(ability)
+    if charges == nil then
+        return true
+    end
+    return charges > 0
+end
+
+local function can_use_item(hero)
+    if not hero then
+        return false
+    end
     for _, state in ipairs(CONTROL_BLOCKERS) do
         if NPC.HasState(hero, state) then
             return false
         end
     end
+    return true
+end
 
+local function collect_enemies(hero, radius)
+    local enemies = {}
+    local raw = Entity.GetHeroesInRadius(hero, radius, Enum.TeamType.TEAM_ENEMY, true, true)
+    if raw then
+        for _, enemy in ipairs(raw) do
+            if enemy ~= hero and Entity.IsAlive(enemy) and not Entity.IsDormant(enemy) and not NPC.IsIllusion(enemy) then
+                table.insert(enemies, enemy)
+            end
+        end
+    end
+    return enemies
+end
+
+local function flat_distance(a, b)
+    if not a or not b then
+        return math.huge
+    end
+    local dx = a.x - b.x
+    local dy = a.y - b.y
+    return math.sqrt(dx * dx + dy * dy)
+end
+
+local function find_closest_enemy(hero, radius)
+    local enemies = collect_enemies(hero, radius)
+    if #enemies == 0 then
+        return nil
+    end
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil
+    end
+    local closest = nil
+    local best_distance = math.huge
+    for _, enemy in ipairs(enemies) do
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        local distance = flat_distance(hero_pos, enemy_pos)
+        if distance < best_distance then
+            best_distance = distance
+            closest = enemy
+        end
+    end
+    return closest
+end
+
+local function get_effective_cast_range(hero, ability, def)
+    local range = 0
+    if ability then
+        range = Ability.GetCastRange(ability) or 0
+    end
+    range = math.max(range, def.cast_range_override or 0)
+    local bonus = NPC.GetCastRangeBonus(hero) or 0
+    range = range + bonus
+    if range <= 0 then
+        range = ui.enemy_range:Get()
+    end
+    return range
+end
+
+local function find_enemy_target(hero, ability, def)
+    local range = get_effective_cast_range(hero, ability, def)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil
+    end
+    local enemies = collect_enemies(hero, range)
+    local closest
+    local best_distance = math.huge
+    for _, enemy in ipairs(enemies) do
+        if not def.enemy_modifier or not NPC.HasModifier(enemy, def.enemy_modifier) then
+            local enemy_pos = Entity.GetAbsOrigin(enemy)
+            local distance = flat_distance(hero_pos, enemy_pos)
+            if distance < best_distance then
+                best_distance = distance
+                closest = enemy
+            end
+        end
+    end
+    return closest
+end
+
+local function normalize_flat_vector(vec)
+    if not vec then
+        return nil
+    end
+    vec.z = 0
+    local length = math.sqrt(vec.x * vec.x + vec.y * vec.y)
+    if length <= 0 then
+        return nil
+    end
+    return Vector(vec.x / length, vec.y / length, 0)
+end
+
+local function compute_escape_position(hero, distance)
+    local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil
+    end
+    local direction
+    if enemy then
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        if enemy_pos then
+            direction = Vector(hero_pos.x - enemy_pos.x, hero_pos.y - enemy_pos.y, 0)
+        end
+    end
+    direction = normalize_flat_vector(direction or Vector(1, 0, 0))
+    if not direction then
+        return nil
+    end
+    local target = Vector(hero_pos.x + direction.x * distance, hero_pos.y + direction.y * distance, hero_pos.z)
+    return target
+end
+
+local function can_cast_now(def, hero, ability, detection_enemies)
+    if not can_use_item(hero) then
+        return false
+    end
+    if def.modifier and NPC.HasModifier(hero, def.modifier) then
+        return false
+    end
+    if def.requires_charges and not item_has_charges(ability) then
+        return false
+    end
+    if def.enemy_toggle then
+        local toggle = ui.items[def.id].requires_enemy
+        if toggle and toggle.Get and toggle:Get() and (#detection_enemies == 0) then
+            return false
+        end
+    end
     return true
 end
 
@@ -394,412 +784,157 @@ local function mark_cast(item_id, game_time)
     last_cast_times[item_id] = game_time
 end
 
-local function get_enabled_items()
-    local ordered = priority_widget:List()
-    local enabled = {}
-
-    for _, key in ipairs(ordered) do
-        if priority_widget:Get(key) then
-            enabled[#enabled + 1] = key
+local function build_priority_queue()
+    local queue = {}
+    for _, def in ipairs(ITEM_DEFINITIONS) do
+        local widgets = ui.items[def.id]
+        if widgets and widgets.enabled:Get() then
+            table.insert(queue, {
+                def = def,
+                order = widgets.priority:Get(),
+            })
         end
     end
-
-    return enabled
-end
-
-local function get_inventory_item(hero, definition)
-    if definition.item_name then
-        return NPC.GetItem(hero, definition.item_name, true)
-    end
-
-    if definition.item_names then
-        for _, name in ipairs(definition.item_names) do
-            local item = NPC.GetItem(hero, name, true)
-            if item then
-                return item
-            end
+    table.sort(queue, function(a, b)
+        if a.order == b.order then
+            return a.def.id < b.def.id
         end
-    end
-
-    return nil
+        return a.order < b.order
+    end)
+    return queue
 end
+--#endregion
 
-local function get_effective_cast_range(hero, ability, definition)
-    local range = Ability.GetCastRange(ability)
-    if not range or range < 0 then
-        range = 0
+--#region Casting helpers
+local function cast_meteor_combo(def, hero, ability, detection_enemies, current_health)
+    if #detection_enemies == 0 then
+        return false
     end
-
-    local bonus = NPC.GetCastRangeBonus(hero)
-    if bonus and bonus > 0 then
-        range = range + bonus
-    end
-
-    if definition and definition.range then
-        range = math.max(range, definition.range)
-    end
-
-    if range <= 0 then
-        range = definition and definition.search_range or DEFAULT_SEARCH_RANGE
-    end
-
-    return range
-end
-
-local function find_enemy_target(hero, ability, definition)
-    local range = get_effective_cast_range(hero, ability, definition)
-    if range <= 0 then
-        return nil
-    end
-
-    local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
-    if not enemies or #enemies == 0 then
-        return nil
-    end
-
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    if not hero_pos then
-        return nil
-    end
-
-    local closest_enemy
-    local closest_distance = math.huge
-
-    for _, enemy in ipairs(enemies) do
-        if enemy and Entity.IsAlive(enemy) and not NPC.IsIllusion(enemy) then
-            if not definition.enemy_modifier or not NPC.HasModifier(enemy, definition.enemy_modifier) then
-                local enemy_pos = Entity.GetAbsOrigin(enemy)
-                if enemy_pos then
-                    local distance = hero_pos:Distance2D(enemy_pos)
-                    if distance < closest_distance then
-                        closest_distance = distance
-                        closest_enemy = enemy
+    local glimmer_def = ITEM_BY_ID.glimmer
+    if glimmer_def then
+        local glimmer_widgets = ui.items[glimmer_def.id]
+        if glimmer_widgets and glimmer_widgets.enabled:Get() then
+            local glimmer_threshold = glimmer_widgets.threshold and glimmer_widgets.threshold:Get() or glimmer_def.threshold_default or 50
+            if current_health <= glimmer_threshold then
+                local glimmer = find_item(hero, glimmer_def.ability_names)
+                if glimmer and ability_is_valid(hero, glimmer) and can_cast_now(glimmer_def, hero, glimmer, detection_enemies) then
+                    if not is_recently_cast(glimmer_def.id, GameRules.GetGameTime()) then
+                        Ability.CastTarget(glimmer, hero)
+                        mark_cast(glimmer_def.id, GameRules.GetGameTime())
                     end
                 end
             end
         end
     end
-
-    return closest_enemy
-end
-
-local function find_closest_enemy(hero, range)
-    if range <= 0 then
-        return nil
+    local target = find_enemy_target(hero, ability, def)
+    if not target then
+        return false
     end
-
-    local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
-    if not enemies or #enemies == 0 then
-        return nil
-    end
-
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    if not hero_pos then
-        return nil
-    end
-
-    local closest_enemy
-    local closest_distance = math.huge
-
-    for _, enemy in ipairs(enemies) do
-        if enemy and Entity.IsAlive(enemy) and not NPC.IsIllusion(enemy) then
-            local enemy_pos = Entity.GetAbsOrigin(enemy)
-            if enemy_pos then
-                local distance = hero_pos:Distance2D(enemy_pos)
-                if distance < closest_distance then
-                    closest_distance = distance
-                    closest_enemy = enemy
-                end
-            end
-        end
-    end
-
-    return closest_enemy
-end
-
-local function normalize_flat_vector(vector)
-    if not vector then
-        return nil
-    end
-
-    local length = vector:Length2D()
-    if length <= 0 then
-        return nil
-    end
-
-    vector.x = vector.x / length
-    vector.y = vector.y / length
-    vector.z = 0
-
-    return vector
-end
-
-local function face_direction(hero, direction)
-    if not hero or not direction then
-        return
-    end
-
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    if not hero_pos then
-        return
-    end
-
-    if not Players or not Player or not Player.PrepareUnitOrders or not Players.GetLocal then
-        return
-    end
-
-    local player = Players.GetLocal()
-    if not player then
-        return
-    end
-
-    local move_target = hero_pos + direction * 50
-    move_target.z = hero_pos.z
-    Player.PrepareUnitOrders(
-        player,
-        Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION,
-        nil,
-        move_target,
-        nil,
-        Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_HERO_ONLY,
-        hero,
-        false,
-        false
-    )
-end
-
-local function get_escape_direction(hero, ability, definition)
-    local hero_pos = Entity.GetAbsOrigin(hero)
-    if not hero_pos then
-        return nil, nil
-    end
-
-    local search_range = definition and definition.search_range or DEFAULT_SEARCH_RANGE
-    if ability then
-        search_range = math.max(search_range, get_effective_cast_range(hero, ability, definition))
-    end
-
-    local enemy = find_closest_enemy(hero, search_range)
-    if not enemy then
-        return nil, nil
-    end
-
-    local enemy_pos = Entity.GetAbsOrigin(enemy)
+    local enemy_pos = Entity.GetAbsOrigin(target)
     if not enemy_pos then
-        return nil, nil
-    end
-
-    local direction = hero_pos - enemy_pos
-    direction = normalize_flat_vector(direction)
-
-    if not direction then
-        return nil, nil
-    end
-
-    return direction, enemy
-end
-
-local ESCAPE_TURN_DELAY = 0.2
-local pending_escape_casts = {}
-
-local function clear_pending_escape(item_key)
-    pending_escape_casts[item_key] = nil
-end
-
-local function needs_new_escape(direction, enemy, pending)
-    if not pending then
-        return true
-    end
-
-    if pending.enemy ~= enemy then
-        return true
-    end
-
-    local pending_dir = pending.direction
-    if not pending_dir or not direction then
-        return true
-    end
-
-    local dot = pending_dir.x * direction.x + pending_dir.y * direction.y
-    if dot < 0.95 then
-        return true
-    end
-
-    return false
-end
-
-local function cast_item(hero, item_key, game_time)
-    local definition = ITEM_DEFINITIONS[item_key]
-    if not definition then
         return false
     end
-
-    if is_recently_cast(item_key, game_time) then
-        return false
-    end
-
-    local item = get_inventory_item(hero, definition)
-    if not item then
-        return false
-    end
-
-    if definition.modifier and NPC.HasModifier(hero, definition.modifier) then
-        return false
-    end
-
-    if not Ability.IsReady(item) then
-        return false
-    end
-
-    if definition.requires_charges then
-        local charges = Ability.GetCurrentCharges(item)
-        if not charges or charges <= 0 then
-            return false
-        end
-    end
-
-    local mana = NPC.GetMana(hero)
-    if not Ability.IsCastable(item, mana) then
-        return false
-    end
-
-    if not can_use_item(hero) then
-        return false
-    end
-
-    if definition.requires_enemy then
-        local range = get_effective_cast_range(hero, item, definition)
-        local enemies = Entity.GetHeroesInRadius(hero, range, Enum.TeamType.TEAM_ENEMY, true, true)
-        if not enemies or #enemies == 0 then
-            return false
-        end
-    end
-
-    if definition.type == "no_target" then
-        Ability.CastNoTarget(item)
-    elseif definition.type == "target_self" then
-        Ability.CastTarget(item, hero)
-    elseif definition.type == "target_enemy" then
-        local target = find_enemy_target(hero, item, definition)
-        if not target then
-            return false
-        end
-
-        Ability.CastTarget(item, target)
-    elseif definition.type == "position_enemy" then
-        local target = find_enemy_target(hero, item, definition)
-        if not target then
-            return false
-        end
-
-        local target_pos = Entity.GetAbsOrigin(target)
-        if not target_pos then
-            return false
-        end
-
-        Ability.CastPosition(item, target_pos)
-    elseif definition.type == "escape_self" then
-        local direction, enemy = get_escape_direction(hero, item, definition)
-        if not direction then
-            clear_pending_escape(item_key)
-            return false
-        end
-
-        local pending = pending_escape_casts[item_key]
-
-        if needs_new_escape(direction, enemy, pending) then
-            pending_escape_casts[item_key] = {
-                ready_time = game_time + ESCAPE_TURN_DELAY,
-                direction = direction,
-                enemy = enemy,
-            }
-            face_direction(hero, direction)
-            return false
-        end
-
-        pending.direction = direction
-
-        if game_time < pending.ready_time then
-            face_direction(hero, pending.direction)
-            return false
-        end
-
-        face_direction(hero, pending.direction)
-        Ability.CastTarget(item, hero)
-        clear_pending_escape(item_key)
-    elseif definition.type == "escape_position" then
-        local direction = get_escape_direction(hero, item, definition)
-        if not direction then
-            return false
-        end
-
-        local hero_pos = Entity.GetAbsOrigin(hero)
-        if not hero_pos then
-            return false
-        end
-
-        local distance = definition.escape_distance or get_effective_cast_range(hero, item, definition)
-        if distance <= 0 then
-            distance = 1150
-        end
-
-        local cast_position = hero_pos + direction * distance
-        cast_position.z = hero_pos.z
-
-        Ability.CastPosition(item, cast_position)
-    else
-        return false
-    end
-
-    mark_cast(item_key, game_time)
-
+    Ability.CastPosition(ability, enemy_pos)
     return true
 end
 
-function auto_defender.OnUpdate()
-    if not Engine.IsInGame() then
-        last_cast_times = {}
-        pending_escape_casts = {}
-        return
+local function cast_item(def, hero, detection_enemies, current_health)
+    local ability = find_item(hero, def.ability_names)
+    if not ability then
+        return false
+    end
+    if not ability_is_valid(hero, ability) then
+        return false
+    end
+    if not can_cast_now(def, hero, ability, detection_enemies) then
+        return false
     end
 
+    if def.cast == "target_self" then
+        Ability.CastTarget(ability, hero)
+    elseif def.cast == "no_target" then
+        Ability.CastNoTarget(ability)
+    elseif def.cast == "target_enemy" then
+        local target = find_enemy_target(hero, ability, def)
+        if not target then
+            return false
+        end
+        Ability.CastTarget(ability, target)
+    elseif def.cast == "position_enemy" then
+        local target = find_enemy_target(hero, ability, def)
+        if not target then
+            return false
+        end
+        local enemy_pos = Entity.GetAbsOrigin(target)
+        if not enemy_pos then
+            return false
+        end
+        Ability.CastPosition(ability, enemy_pos)
+    elseif def.cast == "escape_self" then
+        local escape_position = compute_escape_position(hero, 600)
+        if not escape_position then
+            return false
+        end
+        Ability.CastTarget(ability, hero)
+    elseif def.cast == "escape_position" then
+        local blink_distance = def.blink_range or 1200
+        local target_pos = compute_escape_position(hero, blink_distance)
+        if not target_pos then
+            return false
+        end
+        Ability.CastPosition(ability, target_pos)
+    elseif def.cast == "meteor_combo" then
+        return cast_meteor_combo(def, hero, ability, detection_enemies, current_health)
+    else
+        return false
+    end
+    return true
+end
+--#endregion
+
+function auto_defender.OnUpdate()
     if not ui.enable:Get() then
         return
     end
 
-    local hero = Heroes.GetLocal()
-    if not hero or NPC.IsIllusion(hero) or not Entity.IsAlive(hero) or Entity.IsDormant(hero) then
-        pending_escape_casts = {}
+    if not Engine.IsInGame() then
+        last_cast_times = {}
         return
     end
 
-    local max_health = Entity.GetMaxHealth(hero)
-    if max_health <= 0 then
+    local hero = get_local_hero()
+    if not hero then
         return
     end
 
-    local current_health = Entity.GetHealth(hero)
-    local health_percent = (current_health / max_health) * 100.0
+    if NPC.IsChannelingAbility(hero) then
+        return
+    end
 
+    local current_health = health_percent(hero)
+    local detection_enemies = collect_enemies(hero, ui.enemy_range:Get())
     local game_time = GameRules.GetGameTime()
-    local items_to_use = get_enabled_items()
 
-    if #items_to_use == 0 then
-        return
-    end
-
-    for _, key in ipairs(items_to_use) do
-        local threshold_slider = item_thresholds[key]
-        if threshold_slider and health_percent <= threshold_slider:Get() then
-            cast_item(hero, key, game_time)
+    local queue = build_priority_queue()
+    for _, item in ipairs(queue) do
+        local def = item.def
+        local widgets = ui.items[def.id]
+        if widgets then
+            local should_cast = true
+            if widgets.threshold and current_health > widgets.threshold:Get() then
+                should_cast = false
+            end
+            if should_cast and not is_recently_cast(def.id, game_time) then
+                if cast_item(def, hero, detection_enemies, current_health) then
+                    mark_cast(def.id, game_time)
+                end
+            end
         end
     end
 end
 
 function auto_defender.OnGameEnd()
     last_cast_times = {}
-    pending_escape_casts = {}
 end
 
 return auto_defender
-

--- a/script.lua
+++ b/script.lua
@@ -598,6 +598,8 @@ local function ability_is_valid(hero, ability)
     return true
 end
 
+local is_channeling_ability = NPC.IsChannelingAbility or NPC.IsChannellingAbility
+
 local function item_has_charges(ability)
     if not ability then
         return false
@@ -869,7 +871,7 @@ local function process_pending_escapes(hero, detection_enemies)
             pending_escapes[def_id] = nil
         else
             if current_time >= entry.execute_time then
-                if NPC.IsChannellingAbility(hero) then
+                if is_channeling_ability and is_channeling_ability(hero) then
                     entry.execute_time = current_time + 0.05
                 else
                     if ability_is_valid(hero, entry.ability) then
@@ -908,7 +910,7 @@ local function process_pending_eul_blink(hero, detection_enemies)
         end
         return
     end
-    if NPC.IsChannellingAbility(hero) then
+    if is_channeling_ability and is_channeling_ability(hero) then
         return
     end
     if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
@@ -1068,7 +1070,7 @@ function auto_defender.OnUpdate()
     process_pending_escapes(hero, detection_enemies)
     process_pending_eul_blink(hero, detection_enemies)
 
-    if NPC.IsChannellingAbility(hero) then
+    if is_channeling_ability and is_channeling_ability(hero) then
         -- allow only items that explicitly opt-in
         local queue = build_priority_queue()
         for _, item in ipairs(queue) do

--- a/script.lua
+++ b/script.lua
@@ -52,12 +52,58 @@ end
 
 local ui = {
     enable = activation_group:Switch("Enable", true),
+    debug = activation_group:Switch("Enable debug logging", false),
     escape_turn_delay = activation_group:Slider("Force/Hurricane turn delay (ms)", 0, 500, 200, "%dms"),
     enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
     items = {},
     dependencies = {},
 }
 
+--#endregion
+
+--#region Debug helpers
+local DEBUG_REPEAT_SUPPRESS = 0.75
+local debug_cache = {}
+
+local function is_debug_enabled()
+    return ui.debug and ui.debug.Get and ui.debug:Get()
+end
+
+local function emit_debug_message(message)
+    if Log and Log.Write then
+        Log.Write(message)
+    elseif Console and Console.Print then
+        Console.Print(message)
+    else
+        print(message)
+    end
+end
+
+local function debug_log(def, message)
+    if not is_debug_enabled() then
+        return
+    end
+    local def_id = def and def.id or "general"
+    local now = (GameRules and GameRules.GetGameTime and GameRules.GetGameTime()) or os.clock()
+    local entry = debug_cache[def_id]
+    if entry and entry.message == message and now - entry.time < DEBUG_REPEAT_SUPPRESS then
+        return
+    end
+    debug_cache[def_id] = { message = message, time = now }
+    local label = def and def.display_name or "General"
+    emit_debug_message(string.format("[Auto Defender] %s: %s", label, message))
+end
+
+local function debug_clear(def_id)
+    if not is_debug_enabled() then
+        return
+    end
+    if def_id then
+        debug_cache[def_id] = nil
+    else
+        debug_cache = {}
+    end
+end
 --#endregion
 
 --#region Item definitions
@@ -605,27 +651,27 @@ end
 
 local function ability_is_valid(hero, ability)
     if not ability then
-        return false
+        return false, "ability not found"
     end
     if Ability.IsPassive(ability) then
-        return false
+        return false, "ability is passive"
     end
     if Ability.IsHidden(ability) then
-        return false
+        return false, "ability is hidden"
     end
     if Ability.GetOwner(ability) ~= hero then
-        return false
+        return false, "ability owner mismatch"
     end
     if not Ability.IsActivated(ability) then
-        return false
+        return false, "ability not activated"
     end
     if not Ability.IsReady(ability) then
-        return false
+        return false, "ability on cooldown"
     end
     if not Ability.IsCastable(ability, NPC.GetMana(hero)) then
-        return false
+        return false, "not enough mana"
     end
-    return true
+    return true, nil
 end
 
 local is_channeling_ability = NPC.IsChannelingAbility or NPC.IsChannellingAbility
@@ -714,21 +760,21 @@ end
 
 local function can_cast_now(def, hero, ability, detection_enemies)
     if def.modifier and NPC.HasModifier(hero, def.modifier) then
-        return false
+        return false, "modifier already active"
     end
     if def.requires_charges and not item_has_charges(ability) then
-        return false
+        return false, "no charges"
     end
     if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
-        return false
+        return false, "active effect in progress"
     end
     if def.enemy_toggle then
         local toggle = ui.items[def.id].requires_enemy
         if toggle and toggle:Get() and (#detection_enemies == 0) then
-            return false
+            return false, "no nearby enemies"
         end
     end
-    return true
+    return true, nil
 end
 
 local function build_priority_queue()
@@ -770,14 +816,20 @@ local function has_ready_eul_combo(hero, detection_enemies, current_health)
                 local threshold = widgets.threshold and widgets.threshold:Get()
                 if not threshold or current_health <= threshold then
                     local ability = find_item(hero, def.ability_names)
-                    if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
-                        if require_blink then
-                            local blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
-                            if blink_def and blink_ability then
-                                return true
+                    if ability then
+                        local valid = ability_is_valid(hero, ability)
+                        if valid then
+                            local ready = can_cast_now(def, hero, ability, detection_enemies)
+                            if ready then
+                                if require_blink then
+                                    local blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
+                                    if blink_def and blink_ability then
+                                        return true
+                                    end
+                                else
+                                    return true
+                                end
                             end
-                        else
-                            return true
                         end
                     end
                 end
@@ -814,9 +866,15 @@ local function find_ready_blink(hero, detection_enemies)
             local widgets = ui.items[def.id]
             if widgets and widgets.enabled:Get() then
                 local ability = find_item(hero, def.ability_names)
-                if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
-                    if not widgets.threshold or current_health <= widgets.threshold:Get() then
-                        return def, ability
+                if ability then
+                    local valid = ability_is_valid(hero, ability)
+                    if valid then
+                        local ready = can_cast_now(def, hero, ability, detection_enemies)
+                        if ready then
+                            if not widgets.threshold or current_health <= widgets.threshold:Get() then
+                                return def, ability
+                            end
+                        end
                     end
                 end
             end
@@ -827,14 +885,17 @@ end
 
 local function queue_blink_after_eul(eul_def, hero, detection_enemies, blink_def, blink_ability)
     if not blink_def or not blink_ability then
+        debug_log(eul_def, "no blink available for cyclone follow-up")
         blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
     end
     if not blink_def or not blink_ability then
+        debug_log(eul_def, "blink search failed for cyclone follow-up")
         return false
     end
     local blink_distance = blink_def.blink_range or 1200
     local enemy = find_closest_enemy(hero, math.max(ui.enemy_range:Get() or 0, blink_distance))
     if not enemy then
+        debug_log(blink_def, "no enemy found for cyclone follow-up blink")
         return false
     end
     local escape_position = compute_escape_position(hero, enemy, blink_distance)
@@ -847,14 +908,17 @@ local function queue_blink_after_eul(eul_def, hero, detection_enemies, blink_def
         wait_modifier = eul_def and eul_def.modifier or "modifier_eul_cyclone",
         expire_time = GameRules.GetGameTime() + 3.5,
     }
+    debug_log(blink_def, string.format("queued blink after cyclone (%.0f units)", blink_distance))
     return true
 end
 
 local function queue_force_escape(def, hero, ability, closest_enemy)
     if pending_escapes[def.id] then
+        debug_log(def, "escape already queued")
         return true
     end
     if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
+        debug_log(def, "escape active modifier present")
         return false
     end
     local distance = def.escape_distance or 600
@@ -882,6 +946,7 @@ local function queue_force_escape(def, hero, ability, closest_enemy)
         execute_time = GameRules.GetGameTime() + delay,
         threshold_widget = ui.items[def.id].threshold,
     }
+    debug_log(def, string.format("queued escape (delay %.0f ms)", delay * 1000))
     return true
 end
 
@@ -892,14 +957,17 @@ local function process_pending_escapes(hero, detection_enemies)
             pending_escapes[def_id] = nil
         else
             if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
+                debug_log(def, "pending escape ability missing or owner changed")
                 pending_escapes[def_id] = nil
             else
                 local threshold = entry.threshold_widget and entry.threshold_widget:Get() or def.threshold_default or 0
                 if health_percent(hero) > threshold then
+                    debug_log(def, "cancelled pending escape (health above threshold)")
                     pending_escapes[def_id] = nil
                 elseif def.enemy_toggle then
                     local toggle = ui.items[def.id].requires_enemy
                     if toggle and toggle:Get() and (#detection_enemies == 0) then
+                        debug_log(def, "cancelled pending escape (no enemies)")
                         pending_escapes[def_id] = nil
                     end
                 end
@@ -917,8 +985,12 @@ local function process_pending_escapes(hero, detection_enemies)
                 if is_channeling_ability and is_channeling_ability(hero) then
                     entry.execute_time = current_time + 0.05
                 else
-                    if ability_is_valid(hero, entry.ability) then
+                    local valid, reason = ability_is_valid(hero, entry.ability)
+                    if valid then
                         Ability.CastTarget(entry.ability, hero)
+                        debug_log(def, "cast queued escape")
+                    else
+                        debug_log(def, reason or "queued escape ability invalid")
                     end
                     pending_escapes[def_id] = nil
                 end
@@ -957,14 +1029,19 @@ local function process_pending_eul_blink(hero, detection_enemies)
         return
     end
     if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
+        debug_log(blink_def, "blink ability missing for cyclone follow-up")
         pending_eul_blink = nil
         return
     end
-    if not ability_is_valid(hero, entry.ability) then
+    local valid, reason = ability_is_valid(hero, entry.ability)
+    if not valid then
+        debug_log(blink_def, reason or "blink invalid for cyclone follow-up")
         pending_eul_blink = nil
         return
     end
-    if not can_cast_now(blink_def, hero, entry.ability, detection_enemies) then
+    local ready, block_reason = can_cast_now(blink_def, hero, entry.ability, detection_enemies)
+    if not ready then
+        debug_log(blink_def, block_reason or "blink blocked for cyclone follow-up")
         pending_eul_blink = nil
         return
     end
@@ -977,10 +1054,12 @@ local function process_pending_eul_blink(hero, detection_enemies)
         cast_position = compute_escape_position(hero, enemy, entry.distance or blink_def.blink_range or 1200)
     end
     if not cast_position then
+        debug_log(blink_def, "no escape position for cyclone follow-up")
         pending_eul_blink = nil
         return
     end
     Ability.CastPosition(entry.ability, cast_position)
+    debug_log(blink_def, "cast blink after cyclone")
     pending_eul_blink = nil
 end
 --#endregion
@@ -996,12 +1075,16 @@ local function cast_eul_combo(def, hero, ability, detection_enemies)
     if require_blink then
         blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
         if not blink_def or not blink_ability then
+            debug_log(def, "waiting for blink before cyclone")
             return false
         end
     end
 
     Ability.CastTarget(ability, hero)
-    queue_blink_after_eul(def, hero, detection_enemies, blink_def, blink_ability)
+    debug_log(def, "cast cyclone combo")
+    if not queue_blink_after_eul(def, hero, detection_enemies, blink_def, blink_ability) then
+        debug_log(def, "failed to queue blink after cyclone")
+    end
     return true
 end
 
@@ -1021,20 +1104,35 @@ local function cast_meteor_combo(def, hero, ability, detection_enemies)
             or 50
         if health_percent(hero) <= glimmer_threshold then
             local glimmer = find_item(hero, glimmer_def.ability_names)
-            if glimmer and ability_is_valid(hero, glimmer) and can_cast_now(glimmer_def, hero, glimmer, detection_enemies) then
-                Ability.CastTarget(glimmer, hero)
-                casted_glimmer = true
+            if glimmer then
+                local valid, reason = ability_is_valid(hero, glimmer)
+                if valid then
+                    local ready, block = can_cast_now(glimmer_def, hero, glimmer, detection_enemies)
+                    if ready then
+                        Ability.CastTarget(glimmer, hero)
+                        debug_log(glimmer_def, "cast glimmer for meteor combo")
+                        casted_glimmer = true
+                    else
+                        debug_log(glimmer_def, block or "glimmer blocked before meteor")
+                    end
+                else
+                    debug_log(glimmer_def, reason or "glimmer invalid before meteor")
+                end
+            else
+                debug_log(glimmer_def, "glimmer not found for meteor combo")
             end
         end
     end
 
     if require_glimmer then
         if not glimmer_def then
+            debug_log(def, "meteor combo requires glimmer but definition missing")
             return false
         end
         if not casted_glimmer then
             local has_glimmer = glimmer_def.modifier and NPC.HasModifier(hero, glimmer_def.modifier)
             if not has_glimmer then
+                debug_log(def, "meteor combo waiting for glimmer effect")
                 return false
             end
         end
@@ -1042,67 +1140,85 @@ local function cast_meteor_combo(def, hero, ability, detection_enemies)
 
     local target = find_enemy_for_ability(hero, ability, def)
     if not target then
+        debug_log(def, "no enemy found for meteor combo")
         return false
     end
     local enemy_pos = Entity.GetAbsOrigin(target)
     Ability.CastPosition(ability, enemy_pos)
+    debug_log(def, "cast meteor combo")
     return true
 end
 
 local function cast_item(def, hero, detection_enemies)
     local ability = find_item(hero, def.ability_names)
     if not ability then
+        debug_log(def, "item not present in inventory")
         return false
     end
-    if not ability_is_valid(hero, ability) then
+    local valid, reason = ability_is_valid(hero, ability)
+    if not valid then
+        debug_log(def, reason or "ability not ready")
         return false
     end
-    if not can_cast_now(def, hero, ability, detection_enemies) then
+    local ready, block_reason = can_cast_now(def, hero, ability, detection_enemies)
+    if not ready then
+        debug_log(def, block_reason or "cannot cast due to state")
         return false
     end
 
     if def.cast == "target_self" then
         Ability.CastTarget(ability, hero)
+        debug_log(def, "cast on self")
         return true
     elseif def.cast == "no_target" then
         Ability.CastNoTarget(ability)
+        debug_log(def, "cast no target ability")
         return true
     elseif def.cast == "target_enemy" then
         local enemy = find_enemy_for_ability(hero, ability, def)
         if not enemy then
+            debug_log(def, "no enemy in range")
             return false
         end
         Ability.CastTarget(ability, enemy)
+        debug_log(def, string.format("cast on %s", NPC.GetUnitName(enemy) or "enemy"))
         return true
     elseif def.cast == "position_enemy" then
         local enemy = find_enemy_for_ability(hero, ability, def)
         if not enemy then
+            debug_log(def, "no enemy position available")
             return false
         end
         local enemy_pos = Entity.GetAbsOrigin(enemy)
         Ability.CastPosition(ability, enemy_pos)
+        debug_log(def, "cast at enemy position")
         return true
     elseif def.cast == "blink_escape" then
         if pending_eul_blink then
+            debug_log(def, "blink escape blocked (pending cyclone combo)")
             return false
         end
         local current_health = health_percent(hero)
         if has_ready_eul_combo(hero, detection_enemies, current_health) then
+            debug_log(def, "blink escape skipped (cyclone combo ready)")
             return false
         end
         local search_radius = math.max(ui.enemy_range:Get() or 0, def.blink_range or 1200)
         local enemy = find_closest_enemy(hero, search_radius)
         if not enemy then
+            debug_log(def, "no enemy found for blink escape")
             return false
         end
         local blink_distance = def.blink_range or 1200
         local escape_position = compute_escape_position(hero, enemy, blink_distance)
         Ability.CastPosition(ability, escape_position)
+        debug_log(def, "cast blink escape")
         return true
     elseif def.cast == "force_escape" then
         local search_radius = math.max(ui.enemy_range:Get() or 0, def.escape_distance or 600)
         local enemy = find_closest_enemy(hero, search_radius)
         if not enemy then
+            debug_log(def, "no enemy found for force escape")
             return false
         end
         return queue_force_escape(def, hero, ability, enemy)
@@ -1111,18 +1227,21 @@ local function cast_item(def, hero, detection_enemies)
     elseif def.cast == "meteor_combo" then
         return cast_meteor_combo(def, hero, ability, detection_enemies)
     end
+    debug_log(def, "unknown cast type")
     return false
 end
 --#endregion
 
 function auto_defender.OnUpdate()
     if not ui.enable:Get() then
+        debug_log(nil, "automation disabled")
         clear_pending()
         return
     end
 
     local hero = get_local_hero()
     if not hero then
+        debug_log(nil, "local hero unavailable")
         clear_pending()
         return
     end
@@ -1134,6 +1253,7 @@ function auto_defender.OnUpdate()
     process_pending_eul_blink(hero, detection_enemies)
 
     if is_channeling_ability and is_channeling_ability(hero) then
+        debug_log(nil, "skipping casts while channeling")
         -- allow only items that explicitly opt-in
         local queue = build_priority_queue()
         for _, item in ipairs(queue) do
@@ -1143,7 +1263,11 @@ function auto_defender.OnUpdate()
                 if widgets then
                     local should_cast = true
                     if widgets.threshold then
-                        should_cast = current_health <= widgets.threshold:Get()
+                        local threshold_value = widgets.threshold:Get()
+                        should_cast = current_health <= threshold_value
+                        if not should_cast then
+                            debug_log(def, string.format("health %.1f%% above threshold %d%%", current_health, threshold_value))
+                        end
                     end
                     if should_cast then
                         cast_item(def, hero, detection_enemies)
@@ -1161,7 +1285,11 @@ function auto_defender.OnUpdate()
         if widgets then
             local should_cast = true
             if widgets.threshold then
-                should_cast = current_health <= widgets.threshold:Get()
+                local threshold_value = widgets.threshold:Get()
+                should_cast = current_health <= threshold_value
+                if not should_cast then
+                    debug_log(def, string.format("health %.1f%% above threshold %d%%", current_health, threshold_value))
+                end
             end
             if should_cast then
                 cast_item(def, hero, detection_enemies)

--- a/script.lua
+++ b/script.lua
@@ -1,1 +1,1112 @@
+---@diagnostic disable: undefined-global, lowercase-global, param-type-mismatch
 
+local auto_defender = {}
+
+--#region UI setup
+
+local MAIN_FIRST_TAB = "General"
+local MAIN_SECTION = "Auto Defender"
+
+local overview_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, "Overview")
+local overview_page = overview_tab:Create("Overview")
+
+local info_group = overview_page:Create("Info")
+local activation_group = overview_page:Create("Activation")
+local detection_group = overview_page:Create("Enemy Detection")
+
+info_group:Label("Author: GhostyPowa")
+
+local function create_section_tab(second_name, third_name)
+    local second_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, second_name)
+    local third_tab = second_tab:Create(third_name or second_name)
+    local toggles = third_tab:Create("Toggles")
+    local priority = third_tab:Create("Priority")
+    local thresholds = third_tab:Create("Thresholds")
+    local enemy_checks = third_tab:Create("Enemy Checks")
+    priority:Label("Lower priority value means the item attempts earlier")
+    return {
+        toggles = toggles,
+        priority = priority,
+        thresholds = thresholds,
+        enemy = enemy_checks,
+    }
+end
+
+local SECTION_LAYOUT = {
+    { id = "defensive", second = "Defensive", third = "Defensive Items" },
+    { id = "escape", second = "Escape", third = "Escape Tools" },
+    { id = "utility", second = "Utility", third = "Utility Combos" },
+    { id = "offensive", second = "Offensive", third = "Offensive Items" },
+}
+
+local section_groups = {}
+for _, section in ipairs(SECTION_LAYOUT) do
+    section_groups[section.id] = create_section_tab(section.second, section.third)
+end
+
+local ui = {
+    enable = activation_group:Switch("Enable", true),
+    escape_turn_delay = activation_group:Slider("Force/Hurricane turn delay (ms)", 0, 500, 200, "%dms"),
+    enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
+    items = {},
+}
+
+--#endregion
+
+--#region Item definitions
+local ITEM_DEFINITIONS = {
+    {
+        id = "glimmer",
+        display_name = "Glimmer Cape",
+        icon = "panorama/images/items/glimmer_cape_png.vtex_c",
+        ability_names = { "item_glimmer_cape" },
+        cast = "target_self",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_glimmer_cape_fade",
+        category = "defensive",
+    },
+    {
+        id = "ghost",
+        display_name = "Ghost Scepter",
+        icon = "panorama/images/items/ghost_scepter_png.vtex_c",
+        ability_names = { "item_ghost" },
+        cast = "target_self",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_ghost_state",
+        category = "defensive",
+    },
+    {
+        id = "bkb",
+        display_name = "Black King Bar",
+        icon = "panorama/images/items/black_king_bar_png.vtex_c",
+        ability_names = { "item_black_king_bar" },
+        cast = "no_target",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_black_king_bar_immune",
+        category = "defensive",
+    },
+    {
+        id = "pipe",
+        display_name = "Pipe of Insight",
+        icon = "panorama/images/items/pipe_png.vtex_c",
+        ability_names = { "item_pipe" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_pipe_barrier",
+        category = "defensive",
+    },
+    {
+        id = "crimson",
+        display_name = "Crimson Guard",
+        icon = "panorama/images/items/crimson_guard_png.vtex_c",
+        ability_names = { "item_crimson_guard" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_crimson_guard_nostack",
+        category = "defensive",
+    },
+    {
+        id = "blade_mail",
+        display_name = "Blade Mail",
+        icon = "panorama/images/items/blade_mail_png.vtex_c",
+        ability_names = { "item_blade_mail" },
+        cast = "no_target",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_blade_mail_reflect",
+        category = "defensive",
+    },
+    {
+        id = "lotus",
+        display_name = "Lotus Orb",
+        icon = "panorama/images/items/lotus_orb_png.vtex_c",
+        ability_names = { "item_lotus_orb" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_lotus_orb_active",
+        category = "defensive",
+    },
+    {
+        id = "solar_crest",
+        display_name = "Solar Crest",
+        icon = "panorama/images/items/solar_crest_png.vtex_c",
+        ability_names = { "item_solar_crest" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_solar_crest_armor",
+        category = "defensive",
+    },
+    {
+        id = "drum",
+        display_name = "Drum of Endurance",
+        icon = "panorama/images/items/ancient_janggo_png.vtex_c",
+        ability_names = { "item_ancient_janggo" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
+    },
+    {
+        id = "bearing",
+        display_name = "Boots of Bearing",
+        icon = "panorama/images/items/boots_of_bearing_png.vtex_c",
+        ability_names = { "item_boots_of_bearing" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
+    },
+    {
+        id = "force",
+        display_name = "Force Staff",
+        icon = "panorama/images/items/force_staff_png.vtex_c",
+        ability_names = { "item_force_staff" },
+        cast = "force_escape",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        escape_distance = 600,
+        active_modifier = "modifier_item_force_staff_active",
+        category = "escape",
+    },
+    {
+        id = "hurricane",
+        display_name = "Hurricane Pike",
+        icon = "panorama/images/items/hurricane_pike_png.vtex_c",
+        ability_names = { "item_hurricane_pike" },
+        cast = "force_escape",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        escape_distance = 600,
+        active_modifier = "modifier_item_hurricane_pike",
+        category = "escape",
+    },
+    {
+        id = "blink",
+        display_name = "Blink Dagger",
+        icon = "panorama/images/items/blink_png.vtex_c",
+        ability_names = { "item_blink" },
+        cast = "blink_escape",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "swift_blink",
+        display_name = "Swift Blink",
+        icon = "panorama/images/items/swift_blink_png.vtex_c",
+        ability_names = { "item_swift_blink" },
+        cast = "blink_escape",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "arcane_blink",
+        display_name = "Arcane Blink",
+        icon = "panorama/images/items/arcane_blink_png.vtex_c",
+        ability_names = { "item_arcane_blink" },
+        cast = "blink_escape",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "overwhelming_blink",
+        display_name = "Overwhelming Blink",
+        icon = "panorama/images/items/overwhelming_blink_png.vtex_c",
+        ability_names = { "item_overwhelming_blink" },
+        cast = "blink_escape",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        blink_range = 1200,
+        category = "escape",
+    },
+    {
+        id = "meteor",
+        display_name = "Meteor Hammer",
+        icon = "panorama/images/items/meteor_hammer_png.vtex_c",
+        ability_names = { "item_meteor_hammer" },
+        cast = "meteor_combo",
+        no_threshold = true,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "utility",
+    },
+    {
+        id = "blood_grenade",
+        display_name = "Blood Grenade",
+        icon = "panorama/images/items/blood_grenade_png.vtex_c",
+        ability_names = { "item_blood_grenade" },
+        cast = "position_enemy",
+        threshold_default = 60,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "urn",
+        display_name = "Urn of Shadows",
+        icon = "panorama/images/items/urn_of_shadows_png.vtex_c",
+        ability_names = { "item_urn_of_shadows" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
+    },
+    {
+        id = "vessel",
+        display_name = "Spirit Vessel",
+        icon = "panorama/images/items/spirit_vessel_png.vtex_c",
+        ability_names = { "item_spirit_vessel" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        requires_charges = true,
+        category = "defensive",
+    },
+    {
+        id = "disperser",
+        display_name = "Disperser",
+        icon = "panorama/images/items/disperser_png.vtex_c",
+        ability_names = { "item_disperser" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_disperser_speed",
+        category = "defensive",
+    },
+    {
+        id = "eul",
+        display_name = "Eul's Scepter of Divinity",
+        icon = "panorama/images/items/cyclone_png.vtex_c",
+        ability_names = { "item_cyclone" },
+        cast = "eul_combo",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_eul_cyclone",
+        category = "utility",
+    },
+    {
+        id = "ethereal",
+        display_name = "Ethereal Blade",
+        icon = "panorama/images/items/ethereal_blade_png.vtex_c",
+        ability_names = { "item_ethereal_blade" },
+        cast = "target_self",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_ethereal_blade_ethereal",
+        category = "defensive",
+    },
+    {
+        id = "halberd",
+        display_name = "Heaven's Halberd",
+        icon = "panorama/images/items/heavens_halberd_png.vtex_c",
+        ability_names = { "item_heavens_halberd" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "atos",
+        display_name = "Rod of Atos",
+        icon = "panorama/images/items/rod_of_atos_png.vtex_c",
+        ability_names = { "item_rod_of_atos" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 1100,
+        category = "offensive",
+    },
+    {
+        id = "gleipnir",
+        display_name = "Gleipnir",
+        icon = "panorama/images/items/gleipnir_png.vtex_c",
+        ability_names = { "item_gleipnir" },
+        cast = "position_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 1100,
+        category = "offensive",
+    },
+    {
+        id = "diffusal",
+        display_name = "Diffusal Blade",
+        icon = "panorama/images/items/diffusal_blade_png.vtex_c",
+        ability_names = { "item_diffusal_blade", "item_diffusal_blade_2" },
+        cast = "target_enemy",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "nullifier",
+        display_name = "Nullifier",
+        icon = "panorama/images/items/nullifier_png.vtex_c",
+        ability_names = { "item_nullifier" },
+        cast = "target_enemy",
+        threshold_default = 50,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "orchid",
+        display_name = "Orchid Malevolence",
+        icon = "panorama/images/items/orchid_png.vtex_c",
+        ability_names = { "item_orchid" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "bloodthorn",
+        display_name = "Bloodthorn",
+        icon = "panorama/images/items/bloodthorn_png.vtex_c",
+        ability_names = { "item_bloodthorn" },
+        cast = "target_enemy",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 900,
+        category = "offensive",
+    },
+    {
+        id = "hex",
+        display_name = "Scythe of Vyse",
+        icon = "panorama/images/items/sheepstick_png.vtex_c",
+        ability_names = { "item_sheepstick" },
+        cast = "target_enemy",
+        threshold_default = 40,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "offensive",
+    },
+    {
+        id = "abyssal",
+        display_name = "Abyssal Blade",
+        icon = "panorama/images/items/abyssal_blade_png.vtex_c",
+        ability_names = { "item_abyssal_blade" },
+        cast = "target_enemy",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "dagon",
+        display_name = "Dagon",
+        icon = "panorama/images/items/dagon_5_png.vtex_c",
+        ability_names = {
+            "item_dagon_5",
+            "item_dagon_4",
+            "item_dagon_3",
+            "item_dagon_2",
+            "item_dagon",
+        },
+        cast = "target_enemy",
+        threshold_default = 60,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 800,
+        category = "offensive",
+    },
+    {
+        id = "wind_waker",
+        display_name = "Wind Waker",
+        icon = "panorama/images/items/wind_waker_png.vtex_c",
+        ability_names = { "item_wind_waker" },
+        cast = "eul_combo",
+        threshold_default = 35,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_item_wind_waker",
+        category = "utility",
+    },
+    {
+        id = "silver_edge",
+        display_name = "Silver Edge",
+        icon = "panorama/images/items/silver_edge_png.vtex_c",
+        ability_names = { "item_silver_edge" },
+        cast = "no_target",
+        threshold_default = 45,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        cast_range_override = 600,
+        category = "offensive",
+    },
+    {
+        id = "shadow_blade",
+        display_name = "Shadow Blade",
+        icon = "panorama/images/items/shadow_blade_png.vtex_c",
+        ability_names = { "item_invis_sword" },
+        cast = "no_target",
+        threshold_default = 55,
+        enemy_toggle = true,
+        enemy_required_default = true,
+        modifier = "modifier_invisible",
+        category = "offensive",
+    },
+}
+
+local ITEM_BY_ID = {}
+local BLINK_ITEM_IDS = { "blink", "swift_blink", "arcane_blink", "overwhelming_blink" }
+--#endregion
+
+local function apply_icon(widget, icon)
+    if not widget or not icon then
+        return
+    end
+    if widget.SetImage then
+        widget:SetImage(icon)
+    elseif widget.SetIcon then
+        widget:SetIcon(icon)
+    elseif widget.Image then
+        widget:Image(icon)
+    elseif widget.Icon then
+        widget:Icon(icon)
+    end
+end
+
+for index, def in ipairs(ITEM_DEFINITIONS) do
+    ITEM_BY_ID[def.id] = def
+    local section = section_groups[def.category or "defensive"] or section_groups.defensive
+    local entry = {}
+    entry.enabled = section.toggles:Switch(def.display_name, true)
+    apply_icon(entry.enabled, def.icon)
+    entry.priority = section.priority:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
+    apply_icon(entry.priority, def.icon)
+    if not def.no_threshold then
+        entry.threshold = section.thresholds:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
+        apply_icon(entry.threshold, def.icon)
+    end
+    if def.enemy_toggle then
+        entry.requires_enemy = section.enemy:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
+        apply_icon(entry.requires_enemy, def.icon)
+    end
+    ui.items[def.id] = entry
+end
+
+--#region Helpers
+local function get_local_hero()
+    local hero = Heroes.GetLocal()
+    if not hero then
+        return nil
+    end
+    if not Entity.IsAlive(hero) then
+        return nil
+    end
+    if Entity.IsDormant(hero) then
+        return nil
+    end
+    if NPC.IsIllusion(hero) then
+        return nil
+    end
+    return hero
+end
+
+local function health_percent(hero)
+    local health = Entity.GetHealth(hero)
+    local max_health = Entity.GetMaxHealth(hero)
+    if max_health <= 0 then
+        return 100
+    end
+    return (health / max_health) * 100
+end
+
+local function find_item(hero, names)
+    for _, name in ipairs(names) do
+        local ability = NPC.GetItem(hero, name, true)
+        if ability then
+            return ability
+        end
+    end
+    return nil
+end
+
+local function ability_is_valid(hero, ability)
+    if not ability then
+        return false
+    end
+    if Ability.IsPassive(ability) then
+        return false
+    end
+    if Ability.IsHidden(ability) then
+        return false
+    end
+    if Ability.GetOwner(ability) ~= hero then
+        return false
+    end
+    if not Ability.IsActivated(ability) then
+        return false
+    end
+    if not Ability.IsReady(ability) then
+        return false
+    end
+    if not Ability.IsCastable(ability, NPC.GetMana(hero)) then
+        return false
+    end
+    return true
+end
+
+local function item_has_charges(ability)
+    if not ability then
+        return false
+    end
+    local charges = Ability.GetCurrentCharges(ability)
+    if charges == nil then
+        return true
+    end
+    return charges > 0
+end
+
+local function collect_enemies(hero, radius)
+    local enemies = Entity.GetHeroesInRadius(hero, radius, Enum.TeamType.TEAM_ENEMY, true, true)
+    local result = {}
+    if not enemies then
+        return result
+    end
+    for _, enemy in ipairs(enemies) do
+        if enemy ~= hero and Entity.IsAlive(enemy) and not Entity.IsDormant(enemy) and not NPC.IsIllusion(enemy) then
+            table.insert(result, enemy)
+        end
+    end
+    return result
+end
+
+local function find_closest_enemy(hero, search_radius)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    local enemies = collect_enemies(hero, search_radius)
+    local closest, best_distance = nil, math.huge
+    for _, enemy in ipairs(enemies) do
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        local distance = hero_pos:Distance(enemy_pos)
+        if distance < best_distance then
+            best_distance = distance
+            closest = enemy
+        end
+    end
+    return closest, best_distance
+end
+
+local function find_enemy_for_ability(hero, ability, def)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    local cast_range = def.cast_range_override or Ability.GetCastRange(ability)
+    if not cast_range or cast_range <= 0 then
+        cast_range = 600
+    end
+    local bonus = NPC.GetCastRangeBonus(hero) or 0
+    cast_range = cast_range + bonus + 50
+    local search_radius = math.max(cast_range, ui.enemy_range:Get())
+    local enemies = collect_enemies(hero, search_radius)
+    local best_enemy, best_distance = nil, math.huge
+    for _, enemy in ipairs(enemies) do
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        local distance = hero_pos:Distance(enemy_pos)
+        if distance <= cast_range and distance < best_distance then
+            best_distance = distance
+            best_enemy = enemy
+        end
+    end
+    return best_enemy, best_distance
+end
+
+local function compute_escape_position(hero, enemy, distance)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    local direction
+    if enemy then
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        direction = hero_pos - enemy_pos
+    else
+        local forward = Entity.GetForwardPosition(hero, 10)
+        direction = hero_pos - forward
+    end
+    if math.abs(direction.x) < 0.001 and math.abs(direction.y) < 0.001 then
+        direction = Vector(1, 0, 0)
+    end
+    direction.z = 0
+    local normalized = direction:Normalized()
+    local target = hero_pos + normalized:Scaled(distance)
+    target.z = hero_pos.z
+    return target
+end
+
+local function can_cast_now(def, hero, ability, detection_enemies)
+    if def.modifier and NPC.HasModifier(hero, def.modifier) then
+        return false
+    end
+    if def.requires_charges and not item_has_charges(ability) then
+        return false
+    end
+    if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
+        return false
+    end
+    if def.enemy_toggle then
+        local toggle = ui.items[def.id].requires_enemy
+        if toggle and toggle:Get() and (#detection_enemies == 0) then
+            return false
+        end
+    end
+    return true
+end
+
+local function build_priority_queue()
+    local queue = {}
+    for _, def in ipairs(ITEM_DEFINITIONS) do
+        local widgets = ui.items[def.id]
+        if widgets and widgets.enabled:Get() then
+            table.insert(queue, {
+                def = def,
+                order = widgets.priority:Get(),
+            })
+        end
+    end
+    table.sort(queue, function(a, b)
+        if a.def.cast == "eul_combo" and b.def.cast == "blink_escape" then
+            return true
+        end
+        if a.def.cast == "blink_escape" and b.def.cast == "eul_combo" then
+            return false
+        end
+        if a.order == b.order then
+            return a.def.id < b.def.id
+        end
+        return a.order < b.order
+    end)
+    return queue
+end
+
+local function has_ready_eul_combo(hero, detection_enemies, current_health)
+    current_health = current_health or health_percent(hero)
+    for _, def in ipairs(ITEM_DEFINITIONS) do
+        if def.cast == "eul_combo" then
+            local widgets = ui.items[def.id]
+            if widgets and widgets.enabled:Get() then
+                local threshold = widgets.threshold and widgets.threshold:Get()
+                if not threshold or current_health <= threshold then
+                    local ability = find_item(hero, def.ability_names)
+                    if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    return false
+end
+--#endregion
+
+--#region Pending escape handling
+local pending_escapes = {}
+local pending_eul_blink = nil
+
+local function clear_pending(def_id)
+    if def_id then
+        pending_escapes[def_id] = nil
+        if pending_eul_blink and pending_eul_blink.def and pending_eul_blink.def.id == def_id then
+            pending_eul_blink = nil
+        end
+        return
+    end
+    for key in pairs(pending_escapes) do
+        pending_escapes[key] = nil
+    end
+    pending_eul_blink = nil
+end
+
+local function find_ready_blink(hero, detection_enemies)
+    local current_health = health_percent(hero)
+    for _, id in ipairs(BLINK_ITEM_IDS) do
+        local def = ITEM_BY_ID[id]
+        if def then
+            local widgets = ui.items[def.id]
+            if widgets and widgets.enabled:Get() then
+                local ability = find_item(hero, def.ability_names)
+                if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
+                    if not widgets.threshold or current_health <= widgets.threshold:Get() then
+                        return def, ability
+                    end
+                end
+            end
+        end
+    end
+    return nil, nil
+end
+
+local function queue_blink_after_eul(eul_def, hero, detection_enemies)
+    local blink_def, blink_ability = find_ready_blink(hero, detection_enemies)
+    if not blink_def or not blink_ability then
+        return false
+    end
+    local blink_distance = blink_def.blink_range or 1200
+    local enemy = find_closest_enemy(hero, math.max(ui.enemy_range:Get() or 0, blink_distance))
+    if not enemy then
+        return false
+    end
+    local escape_position = compute_escape_position(hero, enemy, blink_distance)
+    pending_eul_blink = {
+        def = blink_def,
+        ability = blink_ability,
+        enemy = enemy,
+        escape_position = escape_position,
+        distance = blink_distance,
+        wait_modifier = eul_def and eul_def.modifier or "modifier_eul_cyclone",
+        expire_time = GameRules.GetGameTime() + 3.5,
+    }
+    return true
+end
+
+local function queue_force_escape(def, hero, ability, closest_enemy)
+    if pending_escapes[def.id] then
+        return true
+    end
+    if def.active_modifier and NPC.HasModifier(hero, def.active_modifier) then
+        return false
+    end
+    local distance = def.escape_distance or 600
+    local escape_position = compute_escape_position(hero, closest_enemy, distance)
+    local player = Players.GetLocal()
+    if player then
+        Player.PrepareUnitOrders(
+            player,
+            Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION,
+            nil,
+            escape_position,
+            nil,
+            Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_HERO_ONLY,
+            hero,
+            false,
+            false,
+            nil,
+            true
+        )
+    end
+    local delay = (ui.escape_turn_delay:Get() or 0) / 1000
+    pending_escapes[def.id] = {
+        ability = ability,
+        ability_index = Ability.GetIndex(ability),
+        execute_time = GameRules.GetGameTime() + delay,
+        threshold_widget = ui.items[def.id].threshold,
+    }
+    return true
+end
+
+local function process_pending_escapes(hero, detection_enemies)
+    for def_id, entry in pairs(pending_escapes) do
+        local def = ITEM_BY_ID[def_id]
+        if not def then
+            pending_escapes[def_id] = nil
+        else
+            if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
+                pending_escapes[def_id] = nil
+            else
+                local threshold = entry.threshold_widget and entry.threshold_widget:Get() or def.threshold_default or 0
+                if health_percent(hero) > threshold then
+                    pending_escapes[def_id] = nil
+                elseif def.enemy_toggle then
+                    local toggle = ui.items[def.id].requires_enemy
+                    if toggle and toggle:Get() and (#detection_enemies == 0) then
+                        pending_escapes[def_id] = nil
+                    end
+                end
+            end
+        end
+    end
+
+    local current_time = GameRules.GetGameTime()
+    for def_id, entry in pairs(pending_escapes) do
+        local def = ITEM_BY_ID[def_id]
+        if not def then
+            pending_escapes[def_id] = nil
+        else
+            if current_time >= entry.execute_time then
+                if NPC.IsChannellingAbility(hero) then
+                    entry.execute_time = current_time + 0.05
+                else
+                    if ability_is_valid(hero, entry.ability) then
+                        Ability.CastTarget(entry.ability, hero)
+                    end
+                    pending_escapes[def_id] = nil
+                end
+            end
+        end
+    end
+end
+
+local function process_pending_eul_blink(hero, detection_enemies)
+    if not pending_eul_blink then
+        return
+    end
+    local entry = pending_eul_blink
+    local blink_def = entry.def
+    if not blink_def then
+        pending_eul_blink = nil
+        return
+    end
+    local widgets = ui.items[blink_def.id]
+    if not widgets or not widgets.enabled:Get() then
+        pending_eul_blink = nil
+        return
+    end
+    local current_health = health_percent(hero)
+    if widgets.threshold and current_health > widgets.threshold:Get() then
+        pending_eul_blink = nil
+        return
+    end
+    if entry.wait_modifier and NPC.HasModifier(hero, entry.wait_modifier) then
+        if entry.expire_time and GameRules.GetGameTime() > entry.expire_time then
+            pending_eul_blink = nil
+        end
+        return
+    end
+    if NPC.IsChannellingAbility(hero) then
+        return
+    end
+    if not entry.ability or Ability.GetOwner(entry.ability) ~= hero then
+        pending_eul_blink = nil
+        return
+    end
+    if not ability_is_valid(hero, entry.ability) then
+        pending_eul_blink = nil
+        return
+    end
+    if not can_cast_now(blink_def, hero, entry.ability, detection_enemies) then
+        pending_eul_blink = nil
+        return
+    end
+    local enemy = entry.enemy
+    if not enemy or not Entity.IsAlive(enemy) or Entity.IsDormant(enemy) or NPC.IsIllusion(enemy) then
+        enemy = find_closest_enemy(hero, math.max(ui.enemy_range:Get() or 0, entry.distance or blink_def.blink_range or 1200))
+    end
+    local cast_position = entry.escape_position
+    if enemy then
+        cast_position = compute_escape_position(hero, enemy, entry.distance or blink_def.blink_range or 1200)
+    end
+    if not cast_position then
+        pending_eul_blink = nil
+        return
+    end
+    Ability.CastPosition(entry.ability, cast_position)
+    pending_eul_blink = nil
+end
+--#endregion
+
+--#region Casting logic
+local function cast_eul_combo(def, hero, ability, detection_enemies)
+    Ability.CastTarget(ability, hero)
+    queue_blink_after_eul(def, hero, detection_enemies)
+    return true
+end
+
+local function cast_meteor_combo(def, hero, ability, detection_enemies)
+    local glimmer_def = ITEM_BY_ID.glimmer
+    if not glimmer_def then
+        return false
+    end
+    local glimmer_widgets = ui.items[glimmer_def.id]
+    if not glimmer_widgets or not glimmer_widgets.enabled:Get() then
+        return false
+    end
+
+    local glimmer_threshold = glimmer_widgets.threshold and glimmer_widgets.threshold:Get() or glimmer_def.threshold_default or 50
+    if health_percent(hero) > glimmer_threshold then
+        return false
+    end
+
+    local casted_glimmer = false
+    local glimmer = find_item(hero, glimmer_def.ability_names)
+    if glimmer and ability_is_valid(hero, glimmer) and can_cast_now(glimmer_def, hero, glimmer, detection_enemies) then
+        Ability.CastTarget(glimmer, hero)
+        casted_glimmer = true
+    end
+
+    if not casted_glimmer then
+        if not (glimmer_def.modifier and NPC.HasModifier(hero, glimmer_def.modifier)) then
+            return false
+        end
+    end
+
+    local target = find_enemy_for_ability(hero, ability, def)
+    if not target then
+        return false
+    end
+    local enemy_pos = Entity.GetAbsOrigin(target)
+    Ability.CastPosition(ability, enemy_pos)
+    return true
+end
+
+local function cast_item(def, hero, detection_enemies)
+    local ability = find_item(hero, def.ability_names)
+    if not ability then
+        return false
+    end
+    if not ability_is_valid(hero, ability) then
+        return false
+    end
+    if not can_cast_now(def, hero, ability, detection_enemies) then
+        return false
+    end
+
+    if def.cast == "target_self" then
+        Ability.CastTarget(ability, hero)
+        return true
+    elseif def.cast == "no_target" then
+        Ability.CastNoTarget(ability)
+        return true
+    elseif def.cast == "target_enemy" then
+        local enemy = find_enemy_for_ability(hero, ability, def)
+        if not enemy then
+            return false
+        end
+        Ability.CastTarget(ability, enemy)
+        return true
+    elseif def.cast == "position_enemy" then
+        local enemy = find_enemy_for_ability(hero, ability, def)
+        if not enemy then
+            return false
+        end
+        local enemy_pos = Entity.GetAbsOrigin(enemy)
+        Ability.CastPosition(ability, enemy_pos)
+        return true
+    elseif def.cast == "blink_escape" then
+        if pending_eul_blink then
+            return false
+        end
+        local current_health = health_percent(hero)
+        if has_ready_eul_combo(hero, detection_enemies, current_health) then
+            return false
+        end
+        local search_radius = math.max(ui.enemy_range:Get() or 0, def.blink_range or 1200)
+        local enemy = find_closest_enemy(hero, search_radius)
+        if not enemy then
+            return false
+        end
+        local blink_distance = def.blink_range or 1200
+        local escape_position = compute_escape_position(hero, enemy, blink_distance)
+        Ability.CastPosition(ability, escape_position)
+        return true
+    elseif def.cast == "force_escape" then
+        local search_radius = math.max(ui.enemy_range:Get() or 0, def.escape_distance or 600)
+        local enemy = find_closest_enemy(hero, search_radius)
+        if not enemy then
+            return false
+        end
+        return queue_force_escape(def, hero, ability, enemy)
+    elseif def.cast == "eul_combo" then
+        return cast_eul_combo(def, hero, ability, detection_enemies)
+    elseif def.cast == "meteor_combo" then
+        return cast_meteor_combo(def, hero, ability, detection_enemies)
+    end
+    return false
+end
+--#endregion
+
+function auto_defender.OnUpdate()
+    if not ui.enable:Get() then
+        clear_pending()
+        return
+    end
+
+    local hero = get_local_hero()
+    if not hero then
+        clear_pending()
+        return
+    end
+
+    local current_health = health_percent(hero)
+    local detection_enemies = collect_enemies(hero, ui.enemy_range:Get())
+
+    process_pending_escapes(hero, detection_enemies)
+    process_pending_eul_blink(hero, detection_enemies)
+
+    if NPC.IsChannellingAbility(hero) then
+        -- allow only items that explicitly opt-in
+        local queue = build_priority_queue()
+        for _, item in ipairs(queue) do
+            local def = item.def
+            if def.allow_while_channeling then
+                local widgets = ui.items[def.id]
+                if widgets then
+                    local should_cast = true
+                    if widgets.threshold then
+                        should_cast = current_health <= widgets.threshold:Get()
+                    end
+                    if should_cast then
+                        cast_item(def, hero, detection_enemies)
+                    end
+                end
+            end
+        end
+        return
+    end
+
+    local queue = build_priority_queue()
+    for _, item in ipairs(queue) do
+        local def = item.def
+        local widgets = ui.items[def.id]
+        if widgets then
+            local should_cast = true
+            if widgets.threshold then
+                should_cast = current_health <= widgets.threshold:Get()
+            end
+            if should_cast then
+                cast_item(def, hero, detection_enemies)
+            end
+        end
+    end
+end
+
+function auto_defender.OnGameEnd()
+    clear_pending()
+end
+
+return auto_defender

--- a/script.lua
+++ b/script.lua
@@ -3,53 +3,25 @@
 local auto_defender = {}
 
 --#region UI setup
+local tab = Menu.Create("General", "Auto Defender", "Auto Defender", "Auto Defender")
 
-local MAIN_FIRST_TAB = "General"
-local MAIN_SECTION = "Auto Defender"
-
-local overview_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, "Overview")
-local overview_page = overview_tab:Create("Overview")
-
-local info_group = overview_page:Create("Info")
-local activation_group = overview_page:Create("Activation")
-local detection_group = overview_page:Create("Enemy Detection")
+local info_group = tab:Create("Info")
+local activation_group = tab:Create("Activation", 1)
+local items_group = tab:Create("Items", 2)
+local priority_group = tab:Create("Priority", 3)
+local threshold_group = tab:Create("Health Thresholds", 4)
+local enemy_group = tab:Create("Enemy Checks", 5)
 
 info_group:Label("Author: GhostyPowa")
-
-local function create_section_tab(second_name, third_name)
-    local second_tab = Menu.Create(MAIN_FIRST_TAB, MAIN_SECTION, second_name)
-    local third_tab = second_tab:Create(third_name or second_name)
-    local toggles = third_tab:Create("Toggles")
-    local priority = third_tab:Create("Priority")
-    local thresholds = third_tab:Create("Thresholds")
-    local enemy_checks = third_tab:Create("Enemy Checks")
-    priority:Label("Lower priority value means the item attempts earlier")
-    return {
-        toggles = toggles,
-        priority = priority,
-        thresholds = thresholds,
-        enemy = enemy_checks,
-    }
-end
-
-local SECTION_LAYOUT = {
-    { id = "defensive", second = "Defensive", third = "Defensive Items" },
-    { id = "escape", second = "Escape", third = "Escape Tools" },
-    { id = "utility", second = "Utility", third = "Utility Combos" },
-    { id = "offensive", second = "Offensive", third = "Offensive Items" },
-}
-
-local section_groups = {}
-for _, section in ipairs(SECTION_LAYOUT) do
-    section_groups[section.id] = create_section_tab(section.second, section.third)
-end
 
 local ui = {
     enable = activation_group:Switch("Enable", true),
     escape_turn_delay = activation_group:Slider("Force/Hurricane turn delay (ms)", 0, 500, 200, "%dms"),
-    enemy_range = detection_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
+    enemy_range = enemy_group:Slider("Enemy detection range", 200, 2000, 900, "%d"),
     items = {},
 }
+
+priority_group:Label("Lower priority value means the item attempts earlier")
 
 --#endregion
 
@@ -65,7 +37,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_glimmer_cape_fade",
-        category = "defensive",
     },
     {
         id = "ghost",
@@ -77,7 +48,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_ghost_state",
-        category = "defensive",
     },
     {
         id = "bkb",
@@ -89,7 +59,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_black_king_bar_immune",
-        category = "defensive",
     },
     {
         id = "pipe",
@@ -101,7 +70,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_pipe_barrier",
-        category = "defensive",
     },
     {
         id = "crimson",
@@ -113,7 +81,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_crimson_guard_nostack",
-        category = "defensive",
     },
     {
         id = "blade_mail",
@@ -125,7 +92,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_blade_mail_reflect",
-        category = "defensive",
     },
     {
         id = "lotus",
@@ -137,7 +103,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_lotus_orb_active",
-        category = "defensive",
     },
     {
         id = "solar_crest",
@@ -149,7 +114,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_solar_crest_armor",
-        category = "defensive",
     },
     {
         id = "drum",
@@ -161,7 +125,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
-        category = "defensive",
     },
     {
         id = "bearing",
@@ -173,7 +136,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
-        category = "defensive",
     },
     {
         id = "force",
@@ -186,7 +148,6 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         escape_distance = 600,
         active_modifier = "modifier_item_force_staff_active",
-        category = "escape",
     },
     {
         id = "hurricane",
@@ -199,7 +160,6 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         escape_distance = 600,
         active_modifier = "modifier_item_hurricane_pike",
-        category = "escape",
     },
     {
         id = "blink",
@@ -211,7 +171,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
-        category = "escape",
     },
     {
         id = "swift_blink",
@@ -223,7 +182,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
-        category = "escape",
     },
     {
         id = "arcane_blink",
@@ -235,7 +193,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
-        category = "escape",
     },
     {
         id = "overwhelming_blink",
@@ -247,7 +204,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         blink_range = 1200,
-        category = "escape",
     },
     {
         id = "meteor",
@@ -259,7 +215,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
-        category = "utility",
     },
     {
         id = "blood_grenade",
@@ -272,7 +227,6 @@ local ITEM_DEFINITIONS = {
         enemy_required_default = true,
         requires_charges = true,
         cast_range_override = 900,
-        category = "offensive",
     },
     {
         id = "urn",
@@ -284,7 +238,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
-        category = "defensive",
     },
     {
         id = "vessel",
@@ -296,7 +249,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         requires_charges = true,
-        category = "defensive",
     },
     {
         id = "disperser",
@@ -308,7 +260,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_disperser_speed",
-        category = "defensive",
     },
     {
         id = "eul",
@@ -320,7 +271,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_eul_cyclone",
-        category = "utility",
     },
     {
         id = "ethereal",
@@ -332,7 +282,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_ethereal_blade_ethereal",
-        category = "defensive",
     },
     {
         id = "halberd",
@@ -344,7 +293,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
-        category = "offensive",
     },
     {
         id = "atos",
@@ -356,7 +304,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 1100,
-        category = "offensive",
     },
     {
         id = "gleipnir",
@@ -368,7 +315,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 1100,
-        category = "offensive",
     },
     {
         id = "diffusal",
@@ -380,7 +326,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
-        category = "offensive",
     },
     {
         id = "nullifier",
@@ -392,7 +337,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
-        category = "offensive",
     },
     {
         id = "orchid",
@@ -404,7 +348,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
-        category = "offensive",
     },
     {
         id = "bloodthorn",
@@ -416,7 +359,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 900,
-        category = "offensive",
     },
     {
         id = "hex",
@@ -428,7 +370,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 800,
-        category = "offensive",
     },
     {
         id = "abyssal",
@@ -440,7 +381,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
-        category = "offensive",
     },
     {
         id = "dagon",
@@ -458,19 +398,17 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 800,
-        category = "offensive",
     },
     {
         id = "wind_waker",
         display_name = "Wind Waker",
         icon = "panorama/images/items/wind_waker_png.vtex_c",
         ability_names = { "item_wind_waker" },
-        cast = "eul_combo",
+        cast = "target_self",
         threshold_default = 35,
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_item_wind_waker",
-        category = "utility",
     },
     {
         id = "silver_edge",
@@ -482,7 +420,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         cast_range_override = 600,
-        category = "offensive",
     },
     {
         id = "shadow_blade",
@@ -494,7 +431,6 @@ local ITEM_DEFINITIONS = {
         enemy_toggle = true,
         enemy_required_default = true,
         modifier = "modifier_invisible",
-        category = "offensive",
     },
 }
 
@@ -502,36 +438,16 @@ local ITEM_BY_ID = {}
 local BLINK_ITEM_IDS = { "blink", "swift_blink", "arcane_blink", "overwhelming_blink" }
 --#endregion
 
-local function apply_icon(widget, icon)
-    if not widget or not icon then
-        return
-    end
-    if widget.SetImage then
-        widget:SetImage(icon)
-    elseif widget.SetIcon then
-        widget:SetIcon(icon)
-    elseif widget.Image then
-        widget:Image(icon)
-    elseif widget.Icon then
-        widget:Icon(icon)
-    end
-end
-
 for index, def in ipairs(ITEM_DEFINITIONS) do
     ITEM_BY_ID[def.id] = def
-    local section = section_groups[def.category or "defensive"] or section_groups.defensive
     local entry = {}
-    entry.enabled = section.toggles:Switch(def.display_name, true)
-    apply_icon(entry.enabled, def.icon)
-    entry.priority = section.priority:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
-    apply_icon(entry.priority, def.icon)
+    entry.enabled = items_group:Switch(def.display_name, true)
+    entry.priority = priority_group:Slider(def.display_name .. " priority", 1, #ITEM_DEFINITIONS, index, "%d")
     if not def.no_threshold then
-        entry.threshold = section.thresholds:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
-        apply_icon(entry.threshold, def.icon)
+        entry.threshold = threshold_group:Slider(def.display_name .. " threshold", 1, 100, def.threshold_default or 50, "%d%%")
     end
     if def.enemy_toggle then
-        entry.requires_enemy = section.enemy:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
-        apply_icon(entry.requires_enemy, def.icon)
+        entry.requires_enemy = enemy_group:Switch(def.display_name .. " requires enemy", def.enemy_required_default or false)
     end
     ui.items[def.id] = entry
 end
@@ -711,12 +627,6 @@ local function build_priority_queue()
         end
     end
     table.sort(queue, function(a, b)
-        if a.def.cast == "eul_combo" and b.def.cast == "blink_escape" then
-            return true
-        end
-        if a.def.cast == "blink_escape" and b.def.cast == "eul_combo" then
-            return false
-        end
         if a.order == b.order then
             return a.def.id < b.def.id
         end
@@ -724,27 +634,7 @@ local function build_priority_queue()
     end)
     return queue
 end
-
-local function has_ready_eul_combo(hero, detection_enemies, current_health)
-    current_health = current_health or health_percent(hero)
-    for _, def in ipairs(ITEM_DEFINITIONS) do
-        if def.cast == "eul_combo" then
-            local widgets = ui.items[def.id]
-            if widgets and widgets.enabled:Get() then
-                local threshold = widgets.threshold and widgets.threshold:Get()
-                if not threshold or current_health <= threshold then
-                    local ability = find_item(hero, def.ability_names)
-                    if ability and ability_is_valid(hero, ability) and can_cast_now(def, hero, ability, detection_enemies) then
-                        return true
-                    end
-                end
-            end
-        end
-    end
-    return false
-end
 --#endregion
-
 --#region Pending escape handling
 local pending_escapes = {}
 local pending_eul_blink = nil
@@ -787,18 +677,18 @@ local function queue_blink_after_eul(eul_def, hero, detection_enemies)
     if not blink_def or not blink_ability then
         return false
     end
-    local blink_distance = blink_def.blink_range or 1200
-    local enemy = find_closest_enemy(hero, math.max(ui.enemy_range:Get() or 0, blink_distance))
+    local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
     if not enemy then
         return false
     end
-    local escape_position = compute_escape_position(hero, enemy, blink_distance)
+    local distance = blink_def.blink_range or 1200
+    local escape_position = compute_escape_position(hero, enemy, distance)
     pending_eul_blink = {
         def = blink_def,
         ability = blink_ability,
         enemy = enemy,
         escape_position = escape_position,
-        distance = blink_distance,
+        distance = distance,
         wait_modifier = eul_def and eul_def.modifier or "modifier_eul_cyclone",
         expire_time = GameRules.GetGameTime() + 3.5,
     }
@@ -925,7 +815,7 @@ local function process_pending_eul_blink(hero, detection_enemies)
     end
     local enemy = entry.enemy
     if not enemy or not Entity.IsAlive(enemy) or Entity.IsDormant(enemy) or NPC.IsIllusion(enemy) then
-        enemy = find_closest_enemy(hero, math.max(ui.enemy_range:Get() or 0, entry.distance or blink_def.blink_range or 1200))
+        enemy = find_closest_enemy(hero, ui.enemy_range:Get())
     end
     local cast_position = entry.escape_position
     if enemy then
@@ -939,7 +829,6 @@ local function process_pending_eul_blink(hero, detection_enemies)
     pending_eul_blink = nil
 end
 --#endregion
-
 --#region Casting logic
 local function cast_eul_combo(def, hero, ability, detection_enemies)
     Ability.CastTarget(ability, hero)
@@ -1021,12 +910,7 @@ local function cast_item(def, hero, detection_enemies)
         if pending_eul_blink then
             return false
         end
-        local current_health = health_percent(hero)
-        if has_ready_eul_combo(hero, detection_enemies, current_health) then
-            return false
-        end
-        local search_radius = math.max(ui.enemy_range:Get() or 0, def.blink_range or 1200)
-        local enemy = find_closest_enemy(hero, search_radius)
+        local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
         if not enemy then
             return false
         end
@@ -1035,8 +919,7 @@ local function cast_item(def, hero, detection_enemies)
         Ability.CastPosition(ability, escape_position)
         return true
     elseif def.cast == "force_escape" then
-        local search_radius = math.max(ui.enemy_range:Get() or 0, def.escape_distance or 600)
-        local enemy = find_closest_enemy(hero, search_radius)
+        local enemy = find_closest_enemy(hero, ui.enemy_range:Get())
         if not enemy then
             return false
         end
@@ -1110,4 +993,3 @@ function auto_defender.OnGameEnd()
 end
 
 return auto_defender
-


### PR DESCRIPTION
## Summary
- rebuild the Auto Defender menu with overview info, per-category tabs, and configurable detection options
- catalog all requested defensive, escape, utility, and offensive items with per-item priority, threshold, and enemy-check settings
- implement casting helpers, escape queues, and cyclone/blink combo handling that respect channeling and configurable delays

## Testing
- not run (Lua runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d473437d7c83219372d978db98c28f